### PR TITLE
feat(chat): implement Kick native chat and multi-platform unified feed

### DIFF
--- a/e2e/share-import-link.spec.ts
+++ b/e2e/share-import-link.spec.ts
@@ -24,6 +24,7 @@ test.describe("Share and Import Link E2E Test", () => {
     await page.getByTestId("platform-kick").click();
     await page.getByTestId("channel-input").fill("xqc");
     await page.getByTestId("add-submit-btn").click();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
     await expect(page.getByTestId("stream-item-xqc")).toBeVisible();
 
     // Act: open share dialog

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2567,6 +2567,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
+ "urlencoding",
  "walkdir",
 ]
 
@@ -5666,6 +5667,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,3 +43,4 @@ tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 cpal = "0.15"
 hound = "3.5"
 sha2 = "0.10"
+urlencoding = "2.1.3"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -7,8 +7,8 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let env_path = Path::new(".env");
+    println!("cargo:rerun-if-changed=.env");
     if env_path.exists() {
-        println!("cargo:rerun-if-changed=.env");
         if let Ok(contents) = fs::read_to_string(env_path) {
             for line in contents.lines() {
                 let line = line.trim();

--- a/src-tauri/src/kick/api.rs
+++ b/src-tauri/src/kick/api.rs
@@ -1,0 +1,51 @@
+use reqwest::Client;
+use serde::Serialize;
+
+use super::error::KickError;
+use super::state::KickAuthInfo;
+
+#[derive(Debug, Serialize)]
+pub struct KickSendChatRequest {
+    pub broadcaster_user_id: u64,
+    pub content: String,
+    #[serde(rename = "type")]
+    pub msg_type: String,
+}
+
+pub async fn send_message(
+    http: &Client,
+    auth: &KickAuthInfo,
+    broadcaster_user_id: u64,
+    content: &str,
+) -> Result<(), KickError> {
+    let url = "https://api.kick.com/public/v1/chat";
+    let payload = KickSendChatRequest {
+        broadcaster_user_id,
+        content: content.to_string(),
+        msg_type: "user".to_string(),
+    };
+
+    let resp = http
+        .post(url)
+        .bearer_auth(&auth.access_token)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(KickError::Http)?;
+
+    if resp.status() == 401 || resp.status() == 403 {
+        return Err(KickError::OAuth(format!(
+            "Auth error sending message: {}",
+            resp.status()
+        )));
+    } else if resp.status() == 429 {
+        return Err(KickError::OAuth("Rate limited by Kick API".to_string()));
+    } else if !resp.status().is_success() {
+        return Err(KickError::OAuth(format!(
+            "Failed to send message: {}",
+            resp.status()
+        )));
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/kick/commands.rs
+++ b/src-tauri/src/kick/commands.rs
@@ -28,6 +28,15 @@ pub async fn kick_login(app: AppHandle, state: State<'_, KickState>) -> Result<(
 }
 
 #[tauri::command]
+pub async fn kick_cancel_login() -> Result<(), KickError> {
+    if let Ok(mut stream) = tokio::net::TcpStream::connect("127.0.0.1:14832").await {
+        use tokio::io::AsyncWriteExt;
+        let _ = stream.write_all(b"GET /cancel HTTP/1.1\r\n\r\n").await;
+    }
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn kick_logout(app: AppHandle, state: State<'_, KickState>) -> Result<(), KickError> {
     *state.auth.lock().await = None;
 

--- a/src-tauri/src/kick/commands.rs
+++ b/src-tauri/src/kick/commands.rs
@@ -7,6 +7,7 @@ use super::state::{KickAuthState, KickState};
 #[tauri::command]
 pub async fn kick_login(app: AppHandle, state: State<'_, KickState>) -> Result<(), KickError> {
     let http = reqwest::Client::builder()
+        .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36")
         .use_rustls_tls()
         .timeout(std::time::Duration::from_secs(30))
         .build()
@@ -52,5 +53,52 @@ pub async fn kick_get_auth_state(state: State<'_, KickState>) -> Result<KickAuth
 }
 
 pub fn init_stored_auth() -> Option<super::state::KickAuthInfo> {
-    oauth::load_auth()
+    if let Some(auth) = oauth::load_auth() {
+        if auth.has_chat_write {
+            return Some(auth);
+        } else {
+            // Se tiver o token antigo sem chat:write, descarta e exige novo login
+            oauth::clear_auth();
+            return None;
+        }
+    }
+    None
+}
+
+#[tauri::command]
+pub async fn kick_send_message(
+    broadcaster_user_id: u64,
+    message: String,
+    state: State<'_, KickState>,
+) -> Result<(), KickError> {
+    let auth = {
+        let auth_guard = state.auth.lock().await;
+        auth_guard.clone()
+    };
+
+    let auth = auth.ok_or_else(|| KickError::OAuth("Not authenticated with Kick".to_string()))?;
+
+    let http = reqwest::Client::builder()
+        .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36")
+        .use_rustls_tls()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(KickError::Http)?;
+
+    // Send message
+    super::api::send_message(&http, &auth, broadcaster_user_id, &message).await?;
+
+    Ok(())
+}
+
+use std::collections::HashSet;
+
+#[tauri::command]
+pub async fn kick_set_channels(
+    app: AppHandle,
+    channels: Vec<(String, u64)>, // Array of (slug, chatroom_id)
+) -> Result<(), KickError> {
+    let channels_set: HashSet<(String, u64)> = channels.into_iter().collect();
+    super::pusher::update_kick_subscriptions(&app, channels_set).await;
+    Ok(())
 }

--- a/src-tauri/src/kick/commands.rs
+++ b/src-tauri/src/kick/commands.rs
@@ -94,10 +94,25 @@ pub async fn kick_send_message(
         .build()
         .map_err(KickError::Http)?;
 
-    // Send message
-    super::api::send_message(&http, &auth, broadcaster_user_id, &message).await?;
+    match super::api::send_message(&http, &auth, broadcaster_user_id, &message).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            if let KickError::OAuth(msg) = &e {
+                if msg.contains("Auth error sending message: 401")
+                    || msg.contains("Auth error sending message: 403")
+                {
+                    let new_auth = super::oauth::refresh_token(&http, &auth.refresh_token).await?;
+                    super::oauth::store_auth(&new_auth)?;
+                    *state.auth.lock().await = Some(new_auth.clone());
 
-    Ok(())
+                    super::api::send_message(&http, &new_auth, broadcaster_user_id, &message)
+                        .await?;
+                    return Ok(());
+                }
+            }
+            Err(e)
+        }
+    }
 }
 
 use std::collections::HashSet;

--- a/src-tauri/src/kick/error.rs
+++ b/src-tauri/src/kick/error.rs
@@ -14,6 +14,9 @@ pub enum KickError {
     #[error("Token refresh failed")]
     TokenRefreshFailed,
 
+    #[error("WebSocket error: {0}")]
+    WebSocket(String),
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/src-tauri/src/kick/mod.rs
+++ b/src-tauri/src/kick/mod.rs
@@ -1,4 +1,6 @@
+pub mod api;
 pub mod commands;
 pub mod error;
 pub mod oauth;
+pub mod pusher;
 pub mod state;

--- a/src-tauri/src/kick/oauth.rs
+++ b/src-tauri/src/kick/oauth.rs
@@ -153,10 +153,14 @@ pub async fn start_pkce_flow(app: &AppHandle, http: &Client) -> Result<KickAuthI
         ));
     }
 
+    let Some(code) = code else {
+        let response = "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n<html><body><h1>Authorization code not found</h1></body></html>";
+        let _ = stream.write_all(response.as_bytes()).await;
+        return Err(KickError::OAuth("Authorization code not found".to_owned()));
+    };
+
     let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<html><head><title>Success</title></head><body style=\"background:#14161a;color:white;display:flex;justify-content:center;align-items:center;height:100vh;font-family:sans-serif;\"><h1>Authentication successful! You can close this window.</h1><script>window.close()</script></body></html>";
     let _ = stream.write_all(response.as_bytes()).await;
-
-    let code = code.ok_or_else(|| KickError::OAuth("Authorization code not found".to_owned()))?;
 
     let token_resp = http
         .post("https://id.kick.com/oauth/token")

--- a/src-tauri/src/kick/oauth.rs
+++ b/src-tauri/src/kick/oauth.rs
@@ -77,9 +77,13 @@ pub async fn start_pkce_flow(app: &AppHandle, http: &Client) -> Result<KickAuthI
 
     let (verifier, challenge) = generate_pkce();
 
+    let mut state_bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut state_bytes);
+    let state = URL_SAFE_NO_PAD.encode(state_bytes);
+
     let auth_url = format!(
-        "https://id.kick.com/oauth/authorize?response_type=code&client_id={}&redirect_uri={}&scope=user:read+chat:write&code_challenge={}&code_challenge_method=S256&state=random123",
-        client_id, REDIRECT_URI, challenge
+        "https://id.kick.com/oauth/authorize?response_type=code&client_id={}&redirect_uri={}&scope=user:read+chat:write&code_challenge={}&code_challenge_method=S256&state={}",
+        client_id, REDIRECT_URI, challenge, state
     );
 
     let listener_result = tokio::net::TcpListener::bind("127.0.0.1:14832").await;
@@ -116,17 +120,23 @@ pub async fn start_pkce_flow(app: &AppHandle, http: &Client) -> Result<KickAuthI
         .map_err(|e| KickError::OAuth(e.to_string()))?;
 
     let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+    if request.contains("GET /cancel") {
+        return Err(KickError::OAuth("Login cancelled by user".to_owned()));
+    }
     let first_line = request.lines().next().unwrap_or("");
     let mut parts = first_line.split_whitespace();
     parts.next(); // GET
     let path = parts.next().unwrap_or("");
 
+    let mut code_param = None;
+    let mut state_param = None;
     let code = if let Some(query) = path.split('?').nth(1) {
-        let mut code_param = None;
         for pair in query.split('&') {
             if let Some((k, v)) = pair.split_once('=') {
                 if k == "code" {
-                    code_param = Some(v.to_string());
+                    code_param = urlencoding::decode(v).map(|s| s.into_owned()).ok();
+                } else if k == "state" {
+                    state_param = urlencoding::decode(v).map(|s| s.into_owned()).ok();
                 }
             }
         }
@@ -134,6 +144,14 @@ pub async fn start_pkce_flow(app: &AppHandle, http: &Client) -> Result<KickAuthI
     } else {
         None
     };
+
+    if state_param.as_deref() != Some(state.as_str()) {
+        let response = "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n<html><body><h1>Invalid state parameter (CSRF protection failed)</h1></body></html>";
+        let _ = stream.write_all(response.as_bytes()).await;
+        return Err(KickError::OAuth(
+            "Invalid state parameter (CSRF protection failed)".to_owned(),
+        ));
+    }
 
     let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<html><head><title>Success</title></head><body style=\"background:#14161a;color:white;display:flex;justify-content:center;align-items:center;height:100vh;font-family:sans-serif;\"><h1>Authentication successful! You can close this window.</h1><script>window.close()</script></body></html>";
     let _ = stream.write_all(response.as_bytes()).await;

--- a/src-tauri/src/kick/pusher.rs
+++ b/src-tauri/src/kick/pusher.rs
@@ -51,20 +51,25 @@ pub async fn update_kick_subscriptions(
         return;
     };
 
-    {
+    let rx = {
         let mut shutdown_guard = state.pusher_shutdown_tx.lock().await;
         if let Some(tx) = shutdown_guard.take() {
             let _ = tx.send(());
         }
-    }
 
-    if new_channels.is_empty() {
+        if new_channels.is_empty() {
+            None
+        } else {
+            let (tx, rx) = oneshot::channel();
+            *shutdown_guard = Some(tx);
+            Some(rx)
+        }
+    };
+
+    let Some(rx) = rx else {
         emit_connection_state(app, "disconnected").await;
         return;
-    }
-
-    let (tx, rx) = oneshot::channel();
-    *state.pusher_shutdown_tx.lock().await = Some(tx);
+    };
 
     let app_clone = app.clone();
     tokio::spawn(async move {
@@ -144,23 +149,22 @@ async fn connect_pusher(
 
     let (mut write, mut read) = ws_stream.split();
 
-    // Wait for pusher:connection_established
-    let mut connected = false;
-    while let Some(msg) = read.next().await {
-        let msg = msg.map_err(|e| KickError::WebSocket(e.to_string()))?;
-        if let Message::Text(text) = msg {
-            if text.contains("pusher:connection_established") {
-                connected = true;
-                break;
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while let Some(msg) = read.next().await {
+            let msg = msg.map_err(|e| KickError::WebSocket(e.to_string()))?;
+            if let Message::Text(text) = msg {
+                if text.contains("pusher:connection_established") {
+                    return Ok(());
+                }
             }
         }
-    }
 
-    if !connected {
-        return Err(KickError::WebSocket(
+        Err(KickError::WebSocket(
             "Failed to receive connection_established".to_string(),
-        ));
-    }
+        ))
+    })
+    .await
+    .map_err(|_| KickError::WebSocket("Connection establishment timeout".to_string()))??;
 
     emit_connection_state(app, "connected").await;
     log::info!(

--- a/src-tauri/src/kick/pusher.rs
+++ b/src-tauri/src/kick/pusher.rs
@@ -1,0 +1,289 @@
+use std::collections::HashSet;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::sync::oneshot;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+use super::error::KickError;
+use super::state::KickState;
+
+const PUSHER_URL: &str = "wss://ws-us2.pusher.com/app/32cbd69e4b950bf97679?protocol=7&client=js&version=8.4.0-rc2&flash=false";
+const JOIN_DELAY_MS: u64 = 150;
+
+#[derive(Debug, Serialize, Clone)]
+pub struct KickConnectionStateEvent {
+    pub state: &'static str,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct KickChatMessage {
+    pub id: String,
+    pub channel: String,
+    pub username: String,
+    pub display_name: String,
+    pub message: String,
+    pub timestamp_ms: u64,
+    pub color: Option<String>,
+    pub badges: Vec<String>,
+    pub emotes: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct PusherEvent {
+    event: String,
+    data: Option<Value>,
+    channel: Option<String>,
+}
+
+async fn emit_connection_state(app: &AppHandle, state: &'static str) {
+    let _ = app.emit("kick-connection-state", KickConnectionStateEvent { state });
+}
+
+pub async fn update_kick_subscriptions(
+    app: &AppHandle,
+    new_channels: HashSet<(String, u64)>, // (slug, chatroom_id)
+) {
+    let Some(state) = app.try_state::<KickState>() else {
+        return;
+    };
+
+    {
+        let mut shutdown_guard = state.pusher_shutdown_tx.lock().await;
+        if let Some(tx) = shutdown_guard.take() {
+            let _ = tx.send(());
+        }
+    }
+
+    if new_channels.is_empty() {
+        emit_connection_state(app, "disconnected").await;
+        return;
+    }
+
+    let (tx, rx) = oneshot::channel();
+    *state.pusher_shutdown_tx.lock().await = Some(tx);
+
+    let app_clone = app.clone();
+    tokio::spawn(async move {
+        run_pusher_loop(app_clone, new_channels, rx).await;
+    });
+}
+
+pub async fn run_pusher_loop(
+    app: AppHandle,
+    channels: HashSet<(String, u64)>,
+    mut shutdown_rx: oneshot::Receiver<()>,
+) {
+    let mut attempt: u32 = 0;
+
+    loop {
+        emit_connection_state(
+            &app,
+            if attempt == 0 {
+                "disconnected"
+            } else {
+                "reconnecting"
+            },
+        )
+        .await;
+
+        tokio::select! {
+            res = connect_pusher(&app, &channels) => {
+                if let Err(e) = res {
+                    log::warn!("[kick-pusher] connection error: {}", e);
+                }
+            }
+            _ = &mut shutdown_rx => {
+                log::info!("[kick-pusher] shutdown requested, exiting loop");
+                break;
+            }
+        }
+
+        let delay = backoff_delay(attempt);
+        attempt += 1;
+        log::info!(
+            "[kick-pusher] reconnecting in {:?} (attempt {})",
+            delay,
+            attempt
+        );
+
+        tokio::select! {
+            _ = tokio::time::sleep(delay) => {}
+            _ = &mut shutdown_rx => {
+                break;
+            }
+        }
+    }
+}
+
+fn backoff_delay(attempt: u32) -> Duration {
+    if attempt == 0 {
+        return Duration::ZERO;
+    }
+    let base = Duration::from_secs(1u64 << attempt.min(6));
+    let cap = Duration::from_secs(60);
+    let delay = base.min(cap);
+
+    let jitter_ms = rand::random::<u64>() % 400;
+    delay + Duration::from_millis(jitter_ms)
+}
+
+async fn connect_pusher(
+    app: &AppHandle,
+    channels: &HashSet<(String, u64)>,
+) -> Result<(), KickError> {
+    let connect_future = connect_async(PUSHER_URL);
+    let (ws_stream, _) = match tokio::time::timeout(Duration::from_secs(10), connect_future).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(e)) => return Err(KickError::WebSocket(e.to_string())),
+        Err(_) => return Err(KickError::WebSocket("Connection timeout".to_string())),
+    };
+
+    let (mut write, mut read) = ws_stream.split();
+
+    // Wait for pusher:connection_established
+    let mut connected = false;
+    while let Some(msg) = read.next().await {
+        let msg = msg.map_err(|e| KickError::WebSocket(e.to_string()))?;
+        if let Message::Text(text) = msg {
+            if text.contains("pusher:connection_established") {
+                connected = true;
+                break;
+            }
+        }
+    }
+
+    if !connected {
+        return Err(KickError::WebSocket(
+            "Failed to receive connection_established".to_string(),
+        ));
+    }
+
+    emit_connection_state(app, "connected").await;
+    log::info!(
+        "[kick-pusher] connected, joining {} channels",
+        channels.len()
+    );
+
+    for (_, chatroom_id) in channels {
+        let subscribe_payload = serde_json::json!({
+            "event": "pusher:subscribe",
+            "data": {
+                "auth": "",
+                "channel": format!("chatrooms.{}.v2", chatroom_id)
+            }
+        });
+
+        write
+            .send(Message::Text(subscribe_payload.to_string()))
+            .await
+            .map_err(|e| KickError::WebSocket(e.to_string()))?;
+
+        tokio::time::sleep(Duration::from_millis(JOIN_DELAY_MS)).await;
+    }
+
+    let mut ping_interval = tokio::time::interval(Duration::from_secs(120));
+
+    loop {
+        tokio::select! {
+            _ = ping_interval.tick() => {
+                let ping_payload = serde_json::json!({
+                    "event": "pusher:ping",
+                    "data": {}
+                });
+                if let Err(e) = write.send(Message::Text(ping_payload.to_string())).await {
+                    log::warn!("[kick-pusher] failed to send ping: {}", e);
+                }
+            }
+            msg = read.next() => {
+                let msg = match msg {
+                    Some(Ok(m)) => m,
+                    Some(Err(e)) => return Err(KickError::WebSocket(e.to_string())),
+                    None => return Err(KickError::WebSocket("stream closed".to_owned())),
+                };
+
+                match msg {
+                    Message::Text(text) => handle_pusher_message(app, channels, &text).await?,
+                    Message::Ping(payload) => {
+                        write.send(Message::Pong(payload)).await
+                            .map_err(|e| KickError::WebSocket(e.to_string()))?;
+                    }
+                    Message::Close(_) => {
+                        return Err(KickError::WebSocket("server closed connection".to_owned()));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+async fn handle_pusher_message(
+    app: &AppHandle,
+    channels: &HashSet<(String, u64)>,
+    text: &str,
+) -> Result<(), KickError> {
+    if let Ok(pusher_event) = serde_json::from_str::<PusherEvent>(text) {
+        if pusher_event.event == "App\\Events\\ChatMessageEvent" {
+            if let (Some(channel_str), Some(data)) = (pusher_event.channel, pusher_event.data) {
+                // Parse inner data which is a stringified JSON
+                if let Some(data_str) = data.as_str() {
+                    if let Ok(payload) = serde_json::from_str::<Value>(data_str) {
+                        let chatroom_id = channel_str
+                            .replace("chatrooms.", "")
+                            .replace(".v2", "")
+                            .parse::<u64>()
+                            .unwrap_or(0);
+
+                        // Find the slug
+                        let slug = channels
+                            .iter()
+                            .find(|(_, id)| *id == chatroom_id)
+                            .map(|(s, _)| s.clone())
+                            .unwrap_or_else(|| chatroom_id.to_string());
+
+                        let id = payload["id"].as_str().unwrap_or("").to_string();
+                        let content = payload["content"].as_str().unwrap_or("").to_string();
+                        let sender = &payload["sender"];
+                        let username = sender["username"].as_str().unwrap_or("").to_string();
+                        let display_name = sender["username"].as_str().unwrap_or("").to_string();
+                        let color = sender["identity"]["color"].as_str().map(|s| s.to_string());
+
+                        let mut badges = Vec::new();
+                        if let Some(badges_array) = sender["identity"]["badges"].as_array() {
+                            for badge in badges_array {
+                                if let Some(badge_type) = badge["type"].as_str() {
+                                    badges.push(badge_type.to_string());
+                                }
+                            }
+                        }
+
+                        // Add chrono for datetime if possible, or just use SystemTime
+                        let timestamp_ms = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_millis() as u64;
+
+                        let msg = KickChatMessage {
+                            id,
+                            channel: slug,
+                            username,
+                            display_name,
+                            message: content,
+                            timestamp_ms,
+                            color,
+                            badges,
+                            emotes: None,
+                        };
+
+                        let _ = app.emit("kick-chat-message", msg);
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src-tauri/src/kick/state.rs
+++ b/src-tauri/src/kick/state.rs
@@ -6,6 +6,8 @@ pub struct KickAuthInfo {
     pub access_token: String,
     pub refresh_token: String,
     pub username: String,
+    #[serde(default)]
+    pub has_chat_write: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,12 +18,14 @@ pub struct KickAuthState {
 
 pub struct KickState {
     pub auth: Mutex<Option<KickAuthInfo>>,
+    pub pusher_shutdown_tx: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
 }
 
 impl KickState {
     pub fn new() -> Self {
         Self {
             auth: Mutex::new(None),
+            pusher_shutdown_tx: Mutex::new(None),
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,9 @@ use twitch::commands::{
 use twitch::state::TwitchState;
 
 mod kick;
-use kick::commands::{kick_get_auth_state, kick_login, kick_logout};
+use kick::commands::{
+    kick_get_auth_state, kick_login, kick_logout, kick_send_message, kick_set_channels,
+};
 use kick::state::KickState;
 
 // fixed port
@@ -127,6 +129,8 @@ pub fn run() {
             kick_login,
             kick_logout,
             kick_get_auth_state,
+            kick_send_message,
+            kick_set_channels,
         ])
         .setup(move |app| {
             app.manage(TranscriptionState(std::sync::Mutex::new(None)));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,8 @@ use twitch::state::TwitchState;
 
 mod kick;
 use kick::commands::{
-    kick_get_auth_state, kick_login, kick_logout, kick_send_message, kick_set_channels,
+    kick_cancel_login, kick_get_auth_state, kick_login, kick_logout, kick_send_message,
+    kick_set_channels,
 };
 use kick::state::KickState;
 
@@ -127,6 +128,7 @@ pub fn run() {
             twitch_get_connection_state,
             twitch_send_message,
             kick_login,
+            kick_cancel_login,
             kick_logout,
             kick_get_auth_state,
             kick_send_message,
@@ -136,8 +138,10 @@ pub fn run() {
             app.manage(TranscriptionState(std::sync::Mutex::new(None)));
 
             let twitch_state = TwitchState::new();
+            app.manage(twitch_state);
+            let state = app.state::<TwitchState>();
             if let Some(stored_auth) = twitch::commands::init_stored_auth(app.handle()) {
-                *twitch_state.auth.try_lock().expect("lock on startup") = Some(stored_auth.clone());
+                *state.auth.try_lock().expect("lock on startup") = Some(stored_auth.clone());
 
                 let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
@@ -188,11 +192,12 @@ pub fn run() {
                     }
                 });
             }
-            app.manage(twitch_state);
 
             let kick_state = KickState::new();
+            app.manage(kick_state);
+            let state = app.state::<KickState>();
             if let Some(stored_auth) = kick::commands::init_stored_auth() {
-                *kick_state.auth.try_lock().expect("lock on startup") = Some(stored_auth.clone());
+                *state.auth.try_lock().expect("lock on startup") = Some(stored_auth.clone());
 
                 let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
@@ -219,7 +224,7 @@ pub fn run() {
                                     let _ = kick::oauth::store_auth(&refreshed);
                                     *state.auth.lock().await = Some(refreshed);
                                 }
-                                Err(_) => {
+                                Err(kick::error::KickError::TokenRefreshFailed) => {
                                     *state.auth.lock().await = None;
                                     kick::oauth::clear_auth();
                                     let _ = app_handle.emit(
@@ -230,13 +235,15 @@ pub fn run() {
                                         },
                                     );
                                 }
+                                Err(_) => {
+                                    // Network error during refresh - preserve credentials
+                                }
                             }
                         }
                         Err(_) => {}
                     }
                 });
             }
-            app.manage(kick_state);
 
             if cfg!(debug_assertions) {
                 app.handle().plugin(

--- a/src/App.vue
+++ b/src/App.vue
@@ -125,12 +125,11 @@ function handleFrameShortcuts(e: MessageEvent) {
 }
 
 watch(streams, (newStreams, oldStreams) => {
-  if (selectedChat.value === UNIFIED_CHAT_ID) {
-    const hasTwitchStreams = newStreams.some((s) => s.platform === "twitch");
-    if (!hasTwitchStreams) {
-      setSelectedChat("");
-    }
-  } else if (selectedChat.value && !newStreams.some((s) => s.channel === selectedChat.value)) {
+  if (
+    selectedChat.value &&
+    selectedChat.value !== UNIFIED_CHAT_ID &&
+    !newStreams.some((s) => s.channel === selectedChat.value)
+  ) {
     setSelectedChat("");
   }
 

--- a/src/components/chat/KickChat.vue
+++ b/src/components/chat/KickChat.vue
@@ -1,16 +1,9 @@
 <script setup lang="ts">
-import BaseChat from "./BaseChat.vue";
-import { PLATFORMS } from "@/config/platforms";
+import KickNativeChat from "./KickNativeChat.vue";
 
 defineProps<{ channel: string }>();
 </script>
 
 <template>
-  <BaseChat platform="kick">
-    <iframe
-      :src="`${PLATFORMS.kick?.chatUrl}/${channel}?readonly=true`"
-      frameborder="0"
-      sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-    />
-  </BaseChat>
+  <KickNativeChat :channel="channel" />
 </template>

--- a/src/components/chat/KickNativeChat.vue
+++ b/src/components/chat/KickNativeChat.vue
@@ -1,0 +1,190 @@
+<script lang="ts" setup>
+import { ref, computed, onMounted, onUnmounted } from "vue";
+import { Send, WifiOff, RefreshCw } from "lucide-vue-next";
+import { useKickChat } from "@/composables/useKickChat";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import UnifiedChatMessage from "./UnifiedChatMessage.vue";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
+import { toast } from "vue-sonner";
+import { useKickAuth } from "@/composables/useKickAuth";
+import { useI18n } from "vue-i18n";
+import LoginPrompt from "./LoginPrompt.vue";
+
+const props = defineProps<{ channel: string }>();
+
+const {
+  messages,
+  connectionState,
+  joinChannel,
+  leaveChannel,
+  removeLastLocalMessage,
+  addLocalMessage,
+} = useKickChat(props.channel);
+const { username, authenticated, loading: authLoading } = useKickAuth();
+const { t } = useI18n();
+
+function openAuthModal() {
+  window.dispatchEvent(new CustomEvent("multistream-show-dialog", { detail: "kick-auth" }));
+}
+
+const channelMessages = computed(() =>
+  [...messages.value]
+    .filter((m) => m.channel.toLowerCase() === props.channel.toLowerCase())
+    .toReversed()
+);
+
+async function sendKickMessage(channel: string, message: string) {
+  const pendingId = `pending-${Date.now()}`;
+  addLocalMessage({
+    id: pendingId,
+    channel,
+    username: username.value || "You",
+    display_name: username.value || "You",
+    message,
+    timestamp_ms: Date.now(),
+    badges: [],
+    isPending: true,
+    platform: "kick",
+  });
+
+  try {
+    const res = await fetch(`https://kick.com/api/v1/channels/${channel}`);
+    if (!res.ok) throw new Error("Channel not found");
+    const data = await res.json();
+    const broadcaster_user_id = data.user_id;
+
+    await invoke("kick_send_message", {
+      broadcasterUserId: broadcaster_user_id,
+      message,
+    });
+  } catch (error) {
+    removeLastLocalMessage(username.value || "You");
+    throw error;
+  }
+}
+
+const newMessage = ref("");
+const isSending = ref(false);
+
+async function handleSend() {
+  const text = newMessage.value.trim();
+  if (!text) return;
+
+  isSending.value = true;
+  try {
+    await sendKickMessage(props.channel, text);
+    newMessage.value = "";
+  } catch (error) {
+    console.error("Failed to send message", error);
+  } finally {
+    isSending.value = false;
+  }
+}
+
+let unlistenError: UnlistenFn | null = null;
+
+onMounted(async () => {
+  await joinChannel();
+  unlistenError = await listen<{ channel: string; message: string }>("kick-chat-error", (event) => {
+    const { channel, message } = event.payload;
+    if (channel.toLowerCase() === props.channel.toLowerCase()) {
+      if (username.value) {
+        const lastText = removeLastLocalMessage(username.value);
+        if (lastText) {
+          toast.error(message);
+          newMessage.value = lastText;
+        }
+      }
+    }
+  });
+});
+
+onUnmounted(async () => {
+  if (unlistenError) {
+    unlistenError();
+  }
+  await leaveChannel();
+});
+</script>
+
+<template>
+  <div class="flex flex-col h-full bg-[#0f1115]">
+    <div
+      v-if="connectionState === 'reconnecting'"
+      class="flex items-center gap-2 px-3 py-1.5 bg-yellow-500/10 border-b border-yellow-500/20 text-yellow-400 text-[11px] font-medium shrink-0"
+    >
+      <RefreshCw class="w-3 h-3 animate-spin" />
+      {{ t("chat.unified.reconnecting") }}
+    </div>
+
+    <div
+      v-if="connectionState === 'disconnected' && channelMessages.length === 0"
+      class="flex-1 flex flex-col items-center justify-center gap-3 p-6 text-center"
+    >
+      <WifiOff class="w-8 h-8 text-gray-600" />
+      <p class="text-sm text-gray-400">{{ t("chat.unified.disconnected") }}</p>
+    </div>
+
+    <div
+      v-else
+      class="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar py-1 flex flex-col-reverse"
+    >
+      <UnifiedChatMessage
+        v-for="msg in channelMessages"
+        :key="msg.id"
+        :message="{
+          ...msg,
+          color: msg.color ?? null,
+          emotes: msg.emotes ?? null,
+        }"
+        :channel-color="'#53fc18'"
+        compact
+      />
+    </div>
+
+    <!-- Message Input Area or Login Prompt -->
+    <LoginPrompt
+      v-if="!authenticated"
+      platform="kick"
+      :loading="authLoading"
+      @connect="openAuthModal"
+    />
+
+    <div v-else class="p-3 border-t border-[#2a2d33] bg-[#0f1115] shrink-0">
+      <form class="flex gap-2" @submit.prevent="handleSend">
+        <Input
+          v-model="newMessage"
+          :placeholder="t('chat.sendPlaceholder')"
+          class="flex-1 bg-[#1a1d24] border-[#2a2d33] text-sm text-gray-200 placeholder:text-gray-500 focus-visible:ring-[#53fc18]"
+          :disabled="connectionState !== 'connected' || isSending"
+        />
+        <Button
+          type="submit"
+          size="icon"
+          class="shrink-0 bg-[#53fc18] hover:bg-[#6afc35] text-[#0f1115] disabled:opacity-50"
+          :disabled="!newMessage.trim() || connectionState !== 'connected' || isSending"
+        >
+          <Send class="w-4 h-4" />
+        </Button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.custom-scrollbar::-webkit-scrollbar {
+  width: 4px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #2a2d33;
+  border-radius: 4px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #3a3f4b;
+}
+</style>

--- a/src/components/chat/KickNativeChat.vue
+++ b/src/components/chat/KickNativeChat.vue
@@ -21,6 +21,7 @@ const {
   leaveChannel,
   removeLastLocalMessage,
   addLocalMessage,
+  getBroadcasterUserId,
 } = useKickChat(props.channel);
 const { username, authenticated, loading: authLoading } = useKickAuth();
 const { t } = useI18n();
@@ -50,10 +51,13 @@ async function sendKickMessage(channel: string, message: string) {
   });
 
   try {
-    const res = await fetch(`https://kick.com/api/v1/channels/${channel}`);
-    if (!res.ok) throw new Error("Channel not found");
-    const data = await res.json();
-    const broadcaster_user_id = data.user_id;
+    let broadcaster_user_id = getBroadcasterUserId();
+    if (!broadcaster_user_id) {
+      const res = await fetch(`https://kick.com/api/v1/channels/${channel}`);
+      if (!res.ok) throw new Error("Channel not found");
+      const data = await res.json();
+      broadcaster_user_id = data.user_id;
+    }
 
     await invoke("kick_send_message", {
       broadcasterUserId: broadcaster_user_id,
@@ -78,6 +82,7 @@ async function handleSend() {
     newMessage.value = "";
   } catch (error) {
     console.error("Failed to send message", error);
+    toast.error(typeof error === "string" ? error : t("chat.sendError"));
   } finally {
     isSending.value = false;
   }

--- a/src/components/chat/LoginPrompt.vue
+++ b/src/components/chat/LoginPrompt.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { Button } from "@/components/ui/button";
+import { KickIcon, TwitchIcon } from "@/components/icons";
+
+defineProps<{
+  platform: "twitch" | "kick";
+  loading?: boolean;
+  position?: "top" | "bottom";
+  subtitleKey?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: "connect"): void;
+}>();
+</script>
+
+<template>
+  <div
+    class="p-3 bg-[#14161a] shrink-0 flex items-center justify-between gap-3"
+    :class="position === 'top' ? 'border-b border-[#2a2d33]' : 'border-t border-[#2a2d33]'"
+  >
+    <div class="flex items-center gap-2.5 overflow-hidden">
+      <div
+        class="w-8 h-8 rounded-lg bg-[#1e2127] border border-[#2a2d33] flex items-center justify-center shrink-0"
+      >
+        <TwitchIcon v-if="platform === 'twitch'" :size="16" :style="{ color: '#9146FF' }" />
+        <KickIcon v-else :size="16" :style="{ color: '#53fc18' }" />
+      </div>
+      <div class="flex flex-col overflow-hidden leading-tight">
+        <span class="text-xs font-medium text-gray-200 truncate">{{ $t("chat.loginPrompt") }}</span>
+        <span class="text-[10px] text-gray-400 truncate mt-0.5">
+          {{
+            subtitleKey
+              ? $t(subtitleKey)
+              : platform === "twitch"
+                ? $t("chat.loginPromptTwitch")
+                : $t("chat.loginPromptKick")
+          }}
+        </span>
+      </div>
+    </div>
+    <Button
+      variant="outline"
+      size="sm"
+      class="h-8 px-3.5 text-xs font-medium transition-all shrink-0 border-[#2a2d33] bg-[#1e2127]"
+      :class="[
+        platform === 'twitch'
+          ? 'text-[#bf94ff] hover:bg-[#9146FF]/10 hover:text-white hover:border-[#9146FF]/40'
+          : 'text-[#53fc18] hover:bg-[#53fc18]/10 hover:text-white hover:border-[#53fc18]/40',
+      ]"
+      :disabled="loading"
+      @click="emit('connect')"
+    >
+      {{ $t("chat.connectAction") }}
+    </Button>
+  </div>
+</template>

--- a/src/components/chat/UnifiedChat.vue
+++ b/src/components/chat/UnifiedChat.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { watch, computed } from "vue";
-import { WifiOff, RefreshCw, MessageSquare, Twitch } from "lucide-vue-next";
+import { WifiOff, RefreshCw, Twitch } from "lucide-vue-next";
+import { useUnifiedChatState } from "@/composables/useUnifiedChatState";
 import { useUnifiedChat } from "@/composables/useUnifiedChat";
 import { useTwitchAuth } from "@/composables/useTwitchAuth";
 import { useEmotes } from "@/composables/useEmotes";
@@ -8,16 +9,15 @@ import { Button } from "@/components/ui/button";
 import UnifiedChatMessage from "./UnifiedChatMessage.vue";
 import { useI18n } from "vue-i18n";
 import { TwitchIcon } from "../icons";
-
+import LoginPrompt from "./LoginPrompt.vue";
 const { messages, connectionState, channelColor, channelAvatars, twitchChannels } =
   useUnifiedChat();
-const { authenticated, loading: authLoading } = useTwitchAuth();
+const { loading: authLoading } = useTwitchAuth();
 const { t } = useI18n();
 const { loadChannelEmotes } = useEmotes();
+const { unifiedChatState } = useUnifiedChatState();
 
 const reversedMessages = computed(() => [...messages.value].toReversed());
-const hasTwitchStreams = computed(() => twitchChannels.value.length > 0);
-
 function openAuthModal() {
   window.dispatchEvent(new CustomEvent("multistream-show-dialog", { detail: "twitch-auth" }));
 }
@@ -41,14 +41,14 @@ watch(
       {{ t("chat.unified.reconnecting") }}
     </div>
 
-    <template v-if="!authenticated">
+    <template v-if="unifiedChatState.warningType === 'full'">
       <div class="flex-1 flex flex-col items-center justify-center gap-4 p-6 text-center">
         <div class="flex items-center justify-center w-12 h-12 rounded-xl">
           <TwitchIcon :size="36" :style="{ color: '#9146FF' }" />
         </div>
         <div class="text-center space-y-1">
           <p class="font-medium text-gray-200">{{ $t("chat.unified.connectTitle") }}</p>
-          <p class="text-sm text-gray-400">{{ $t("chat.unified.connectHint") }}</p>
+          <p class="text-sm text-gray-400">{{ $t(unifiedChatState.warningMessage) }}</p>
         </div>
         <div class="pt-2">
           <Button
@@ -64,15 +64,13 @@ watch(
       </div>
     </template>
 
-    <template v-else-if="!hasTwitchStreams">
-      <div class="flex-1 flex flex-col items-center justify-center gap-3 p-6 text-center">
-        <MessageSquare class="w-8 h-8 text-gray-600" />
-        <p class="text-sm text-gray-400">{{ t("chat.unified.noTwitchStreams") }}</p>
-        <p class="text-xs text-gray-600">{{ t("chat.unified.noTwitchStreamsHint") }}</p>
-      </div>
-    </template>
-
-    <template v-else-if="connectionState === 'disconnected' && messages.length === 0">
+    <template
+      v-else-if="
+        connectionState === 'disconnected' &&
+        messages.length === 0 &&
+        unifiedChatState.activePlatforms.length === 0
+      "
+    >
       <div class="flex-1 flex flex-col items-center justify-center gap-3 p-6 text-center">
         <WifiOff class="w-8 h-8 text-gray-600" />
         <p class="text-sm text-gray-400">{{ t("chat.unified.disconnected") }}</p>
@@ -81,14 +79,24 @@ watch(
 
     <template v-else>
       <div
-        class="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar py-1 flex flex-col-reverse"
+        class="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar pt-1 flex flex-col-reverse"
       >
+        <LoginPrompt
+          v-if="unifiedChatState.warningType === 'banner'"
+          platform="twitch"
+          position="top"
+          :subtitle-key="unifiedChatState.warningMessage"
+          :loading="authLoading"
+          @connect="openAuthModal"
+        />
+
         <UnifiedChatMessage
           v-for="msg in reversedMessages"
           :key="msg.id"
           :message="msg"
           :channel-color="channelColor(msg.channel)"
           :channel-avatar="channelAvatars[msg.channel]"
+          :show-platform-icon="true"
         />
       </div>
     </template>

--- a/src/components/chat/UnifiedChatMessage.vue
+++ b/src/components/chat/UnifiedChatMessage.vue
@@ -2,7 +2,8 @@
 import { computed } from "vue";
 import type { UnifiedChatMessage } from "@/composables/useUnifiedChat";
 import { useEmotes } from "@/composables/useEmotes";
-import { Sword, Crown, Gem, Star } from "lucide-vue-next";
+import { Sword, Crown, Gem, Star, Twitch } from "lucide-vue-next";
+import KickIcon from "@/components/icons/KickIcon.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -10,9 +11,11 @@ const props = withDefaults(
     channelColor: string;
     channelAvatar?: string;
     compact?: boolean;
+    showPlatformIcon?: boolean;
   }>(),
   {
     compact: false,
+    showPlatformIcon: false,
   }
 );
 
@@ -91,6 +94,16 @@ const nameColor = computed(() => props.message.color || "#e5e7eb"); // Default t
 
       <!-- Message Content -->
       <p class="text-sm leading-relaxed break-words text-gray-300 flex-1 min-w-0">
+        <!-- Platform Icon (Only shown in Unified Chat View) -->
+        <span v-if="props.showPlatformIcon" class="inline-flex items-center mr-1.5 align-[-0.1em]">
+          <Twitch v-if="props.message.platform === 'twitch'" class="w-3 h-3 text-[#9146FF]" />
+          <KickIcon
+            v-else-if="props.message.platform === 'kick'"
+            :size="12"
+            :style="{ color: '#53fc18' }"
+          />
+        </span>
+
         <!-- Badges -->
         <component
           :is="badge.icon"
@@ -102,7 +115,10 @@ const nameColor = computed(() => props.message.color || "#e5e7eb"); // Default t
         />
 
         <!-- User Name -->
-        <span class="font-bold mr-1" :style="{ color: nameColor }">
+        <span
+          class="font-bold mr-1 inline-flex items-center gap-1 align-baseline"
+          :style="{ color: nameColor }"
+        >
           {{ props.message.display_name }}<span class="text-gray-400">:</span>
         </span>
 

--- a/src/components/dialogs/KickAuthDialog.vue
+++ b/src/components/dialogs/KickAuthDialog.vue
@@ -23,7 +23,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const { startLogin, authenticated, authUrl } = useKickAuth();
+const { startLogin, cancelLogin, authenticated, authUrl } = useKickAuth();
 
 const authError = ref<string | null>(null);
 
@@ -33,9 +33,8 @@ async function startFlow() {
 }
 
 async function handleCancel() {
+  cancelLogin();
   emit("update:open", false);
-  // Optional: In a full implementation, we could invoke a "kick_cancel_login" command
-  // to terminate the TCP listener. For now, closing the dialog is sufficient.
 }
 
 async function handleOpenLink() {

--- a/src/components/dialogs/SettingsDialog.vue
+++ b/src/components/dialogs/SettingsDialog.vue
@@ -160,10 +160,16 @@ const handleFileImport = (e: Event) => {
         } else {
           toast.error(t("settings.backup.importError"));
         }
+      } else {
+        toast.error(t("settings.backup.importError"));
       }
     } catch (err) {
       toast.error(t("settings.backup.importError"));
     }
+    input.value = "";
+  });
+  reader.addEventListener("error", () => {
+    toast.error(t("settings.backup.importError"));
     input.value = "";
   });
   reader.readAsText(file);

--- a/src/components/dialogs/SettingsDialog.vue
+++ b/src/components/dialogs/SettingsDialog.vue
@@ -150,20 +150,22 @@ const handleFileImport = (e: Event) => {
   const file = input.files?.[0];
   if (!file) return;
   const reader = new FileReader();
-  reader.onload = (event) => {
+  reader.addEventListener("load", (event) => {
     try {
-      const data = JSON.parse(event.target?.result as string);
-      if (validateBackupData(data)) {
-        pendingBackupData.value = data;
-        showImportConfirm.value = true;
-      } else {
-        toast.error(t("settings.backup.importError"));
+      if (typeof event.target?.result === "string") {
+        const data = JSON.parse(event.target.result);
+        if (validateBackupData(data)) {
+          pendingBackupData.value = data;
+          showImportConfirm.value = true;
+        } else {
+          toast.error(t("settings.backup.importError"));
+        }
       }
     } catch (err) {
       toast.error(t("settings.backup.importError"));
     }
     input.value = "";
-  };
+  });
   reader.readAsText(file);
 };
 

--- a/src/components/dialogs/SettingsDialog.vue
+++ b/src/components/dialogs/SettingsDialog.vue
@@ -394,7 +394,7 @@ const authPlatforms = Object.values(PLATFORMS).filter((p) => p.id !== "custom");
                         }}</span>
                         <button
                           class="ml-auto text-gray-400 hover:text-red-400 p-1 rounded transition-colors"
-                          title="Logout"
+                          :title="$t('settings.auth.logout')"
                           @click="twitchLogout"
                         >
                           <LogOut class="w-3.5 h-3.5" />
@@ -429,7 +429,7 @@ const authPlatforms = Object.values(PLATFORMS).filter((p) => p.id !== "custom");
                         }}</span>
                         <button
                           class="ml-auto text-gray-400 hover:text-red-400 p-1 rounded transition-colors"
-                          title="Logout"
+                          :title="$t('settings.auth.logout')"
                           @click="kickLogout"
                         >
                           <LogOut class="w-3.5 h-3.5" />

--- a/src/components/main/SidebarPanel.vue
+++ b/src/components/main/SidebarPanel.vue
@@ -3,13 +3,12 @@ import { ref, onMounted, onUnmounted, computed, defineAsyncComponent, watch } fr
 import { usePreferences } from "@/composables/usePreferences";
 import { useStreams } from "@/composables/useStreams";
 import { useTranscription } from "@/composables/useTranscription";
+import { useUnifiedChatState } from "@/composables/useUnifiedChatState";
 import { Button } from "@/components/ui/button";
 const KickChat = defineAsyncComponent(() => import("@/components/chat/KickChat.vue"));
 const TwitchChat = defineAsyncComponent(() => import("@/components/chat/TwitchChat.vue"));
 const YoutubeChat = defineAsyncComponent(() => import("@/components/chat/YoutubeChat.vue"));
-const UnifiedTwitchChat = defineAsyncComponent(
-  () => import("@/components/chat/UnifiedTwitchChat.vue")
-);
+const UnifiedChat = defineAsyncComponent(() => import("@/components/chat/UnifiedChat.vue"));
 const TranscriptView = defineAsyncComponent(() => import("@/components/chat/TranscriptView.vue"));
 
 const AddDialog = defineAsyncComponent(() => import("@/components/dialogs/AddDialog.vue"));
@@ -93,6 +92,7 @@ const hasLoadedUnifiedChat = ref(false);
 const hasLoadedTranscript = ref(false);
 
 const { streams } = useStreams();
+const { unifiedChatState } = useUnifiedChatState();
 const { selectedChat, sidebarOpen } = usePreferences();
 
 watch(
@@ -108,6 +108,15 @@ watch(
     if (v === "transcript") hasLoadedTranscript.value = true;
   },
   { immediate: true }
+);
+
+watch(
+  () => streams.value.length,
+  (len) => {
+    if (len === 1 && selectedChat.value === UNIFIED_CHAT_ID && streams.value[0]) {
+      selectedChat.value = streams.value[0].channel;
+    }
+  }
 );
 const {
   isActive: transcriptionActive,
@@ -214,7 +223,18 @@ onUnmounted(() => {
             >
               <SelectValue :placeholder="$t('chat.selectPlaceholder')">
                 <div v-if="selectedChat === UNIFIED_CHAT_ID" class="flex items-center gap-2">
-                  <TwitchIcon class="w-4 h-4 shrink-0 text-[#bf94ff]" />
+                  <div class="flex items-center -space-x-1 shrink-0">
+                    <component
+                      :is="platformIcons[platform]"
+                      v-for="platform in unifiedChatState.activePlatforms"
+                      :key="platform"
+                      class="w-4 h-4"
+                      :class="{
+                        'text-[#bf94ff]': platform === 'twitch',
+                        'text-[#53fc18]': platform === 'kick',
+                      }"
+                    />
+                  </div>
                   <span class="truncate">{{ $t("chat.unified.selectorLabel") }}</span>
                 </div>
                 <div v-else-if="selectedStreamObj" class="flex items-center gap-2">
@@ -241,12 +261,23 @@ onUnmounted(() => {
                   </div>
                 </SelectItem>
                 <SelectItem
-                  v-if="streams.some((s) => s.platform === 'twitch')"
+                  v-if="unifiedChatState.showUnifiedChat"
                   :value="UNIFIED_CHAT_ID"
-                  class="text-[#bf94ff] focus:bg-[#2a2d33] focus:text-white cursor-pointer border-t border-[#2a2d33] mt-1 pt-1"
+                  class="text-white focus:bg-[#2a2d33] focus:text-white cursor-pointer border-t border-[#2a2d33] mt-1 pt-1"
                 >
                   <div class="flex items-center gap-2">
-                    <TwitchIcon class="w-4 h-4 shrink-0" />
+                    <div class="flex items-center -space-x-1 shrink-0">
+                      <component
+                        :is="platformIcons[platform]"
+                        v-for="platform in unifiedChatState.activePlatforms"
+                        :key="platform"
+                        class="w-4 h-4"
+                        :class="{
+                          'text-[#bf94ff]': platform === 'twitch',
+                          'text-[#53fc18]': platform === 'kick',
+                        }"
+                      />
+                    </div>
                     <span class="truncate">{{ $t("chat.unified.selectorLabel") }}</span>
                   </div>
                 </SelectItem>
@@ -277,10 +308,7 @@ onUnmounted(() => {
             :key="`chat-${stream.id}`"
             :channel="stream.channel"
           />
-          <UnifiedTwitchChat
-            v-if="hasLoadedUnifiedChat"
-            v-show="selectedChat === UNIFIED_CHAT_ID"
-          />
+          <UnifiedChat v-if="hasLoadedUnifiedChat" v-show="selectedChat === UNIFIED_CHAT_ID" />
           <div
             v-if="streams.length === 0"
             class="absolute inset-0 flex items-center justify-center text-muted-foreground"

--- a/src/composables/__tests__/useKickAuth.spec.ts
+++ b/src/composables/__tests__/useKickAuth.spec.ts
@@ -29,6 +29,7 @@ describe("useKickAuth", () => {
 
   afterEach(() => {
     scope.stop();
+    vi.unstubAllGlobals();
   });
 
   it("initialises as unauthenticated when backend returns false", async () => {

--- a/src/composables/__tests__/useKickAuth.spec.ts
+++ b/src/composables/__tests__/useKickAuth.spec.ts
@@ -1,0 +1,135 @@
+import { effectScope, type EffectScope } from "vue";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock("@/composables/useUpdater", () => ({
+  isTauri: () => true,
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useKickAuth } from "../useKickAuth";
+
+describe("useKickAuth", () => {
+  let scope: EffectScope;
+
+  beforeEach(() => {
+    scope = effectScope();
+    vi.clearAllMocks();
+    (listen as ReturnType<typeof vi.fn>).mockResolvedValue(vi.fn());
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  it("initialises as unauthenticated when backend returns false", async () => {
+    // Arrange
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      authenticated: false,
+      username: null,
+    });
+
+    // Act
+    let auth: ReturnType<typeof useKickAuth>;
+    await scope.run(async () => {
+      auth = useKickAuth();
+      // Wait for ensureInit to finish
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Assert
+    expect(auth!.authenticated.value).toBe(false);
+    expect(auth!.username.value).toBeNull();
+  });
+
+  it("sets authenticated and username from backend response", async () => {
+    // Arrange
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      authenticated: true,
+      username: "kickuser",
+    });
+
+    // Act
+    let auth: ReturnType<typeof useKickAuth>;
+    await scope.run(async () => {
+      auth = useKickAuth();
+      // Wait for ensureInit to finish
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Assert
+    expect(auth!.authenticated.value).toBe(true);
+    expect(auth!.username.value).toBe("kickuser");
+  });
+
+  it("calls kick_login on startLogin()", async () => {
+    // Arrange
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      authenticated: false,
+      username: null,
+    });
+
+    let auth: ReturnType<typeof useKickAuth>;
+    scope.run(() => {
+      auth = useKickAuth();
+    });
+
+    // Act
+    await auth!.startLogin();
+
+    // Assert
+    expect(invoke).toHaveBeenCalledWith("kick_login");
+    expect(auth!.loading.value).toBe(false);
+  });
+
+  it("calls kick_logout on logout()", async () => {
+    // Arrange
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      authenticated: true,
+      username: "kickuser",
+    });
+
+    let auth: ReturnType<typeof useKickAuth>;
+    scope.run(() => {
+      auth = useKickAuth();
+    });
+
+    // Act
+    await auth!.logout();
+
+    // Assert
+    expect(invoke).toHaveBeenCalledWith("kick_logout");
+  });
+
+  it("calls kick_cancel_login on cancelLogin()", async () => {
+    // Arrange
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      authenticated: false,
+      username: null,
+    });
+
+    let auth: ReturnType<typeof useKickAuth>;
+    scope.run(() => {
+      auth = useKickAuth();
+    });
+
+    // Act
+    await auth!.cancelLogin();
+
+    // Assert
+    expect(invoke).toHaveBeenCalledWith("kick_cancel_login");
+  });
+});

--- a/src/composables/__tests__/useKickChat.spec.ts
+++ b/src/composables/__tests__/useKickChat.spec.ts
@@ -10,10 +10,11 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { useKickChat, type KickChatMessage } from "../useKickChat";
+import { useKickChat, __test_resetKickChatState, type KickChatMessage } from "../useKickChat";
 
 describe("useKickChat", () => {
   beforeEach(() => {
+    __test_resetKickChatState();
     vi.clearAllMocks();
     (listen as ReturnType<typeof vi.fn>).mockResolvedValue(vi.fn());
 

--- a/src/composables/__tests__/useKickChat.spec.ts
+++ b/src/composables/__tests__/useKickChat.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useKickChat, type KickChatMessage } from "../useKickChat";
+
+describe("useKickChat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (listen as ReturnType<typeof vi.fn>).mockResolvedValue(vi.fn());
+
+    // Mock global fetch
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sets up IPC listeners upon initialization", async () => {
+    // Arrange
+    const channelSlug = "testchannel";
+
+    // Act
+    useKickChat(channelSlug);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Assert
+    expect(listen).toHaveBeenCalledWith("kick-connection-state", expect.any(Function));
+    expect(listen).toHaveBeenCalledWith("kick-chat-message", expect.any(Function));
+  });
+
+  it("fetches chatroom id and joins channel", async () => {
+    // Arrange
+    const channelSlug = "xqc";
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ chatroom: { id: 12345 } }),
+    };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+
+    const { joinChannel } = useKickChat(channelSlug);
+
+    // Act
+    await joinChannel();
+
+    // Assert
+    expect(globalThis.fetch).toHaveBeenCalledWith(`https://kick.com/api/v1/channels/xqc`);
+    expect(invoke).toHaveBeenCalledWith("kick_set_channels", {
+      channels: [["xqc", 12345]],
+    });
+  });
+
+  it("leaves channel and updates subscriptions", async () => {
+    // Arrange
+    const channelSlug = "xqc";
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ chatroom: { id: 12345 } }),
+    };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+
+    const { joinChannel, leaveChannel } = useKickChat(channelSlug);
+    await joinChannel(); // Ensure it is joined first
+    vi.mocked(invoke).mockClear();
+
+    // Act
+    await leaveChannel();
+
+    // Assert
+    expect(invoke).toHaveBeenCalledWith("kick_set_channels", {
+      channels: [],
+    });
+  });
+
+  it("adds and removes local optimistic messages", () => {
+    // Arrange
+    const channelSlug = "testchannel";
+    const { addLocalMessage, removeLastLocalMessage, messages } = useKickChat(channelSlug);
+
+    const testMessage: KickChatMessage = {
+      id: "local-1",
+      channel: "testchannel",
+      username: "user1",
+      display_name: "User1",
+      message: "Hello world",
+      timestamp_ms: Date.now(),
+      badges: [],
+      isPending: true,
+      platform: "kick",
+    };
+
+    // Act
+    addLocalMessage(testMessage);
+
+    // Assert
+    expect(messages.value).toContainEqual(testMessage);
+
+    // Act 2
+    const removedText = removeLastLocalMessage("user1");
+
+    // Assert 2
+    expect(removedText).toBe("Hello world");
+    expect(messages.value).not.toContainEqual(testMessage);
+  });
+
+  it("returns null if trying to remove local message for unknown user", () => {
+    // Arrange
+    const channelSlug = "testchannel";
+    const { addLocalMessage, removeLastLocalMessage } = useKickChat(channelSlug);
+
+    const testMessage: KickChatMessage = {
+      id: "local-1",
+      channel: "testchannel",
+      username: "user1",
+      display_name: "User1",
+      message: "Hello world",
+      timestamp_ms: Date.now(),
+      badges: [],
+      isPending: true,
+      platform: "kick",
+    };
+
+    // Act
+    addLocalMessage(testMessage);
+    const removedText = removeLastLocalMessage("unknownuser");
+
+    // Assert
+    expect(removedText).toBeNull();
+  });
+});

--- a/src/composables/__tests__/useUnifiedChatState.spec.ts
+++ b/src/composables/__tests__/useUnifiedChatState.spec.ts
@@ -1,0 +1,166 @@
+import { effectScope, ref, type EffectScope } from "vue";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock dependencies
+const mockStreams = ref<any[]>([]);
+vi.mock("@/composables/useStreams", () => ({
+  useStreams: () => ({
+    streams: mockStreams,
+  }),
+}));
+
+const mockAuthenticated = ref(false);
+vi.mock("@/composables/useTwitchAuth", () => ({
+  useTwitchAuth: () => ({
+    authenticated: mockAuthenticated,
+  }),
+}));
+
+import { useUnifiedChatState } from "../useUnifiedChatState";
+
+describe("useUnifiedChatState", () => {
+  let scope: EffectScope;
+
+  beforeEach(() => {
+    scope = effectScope();
+    mockStreams.value = [];
+    mockAuthenticated.value = false;
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  it("does not show unified chat when there are less than 2 total streams", () => {
+    // Arrange
+    mockStreams.value = [{ platform: "twitch", channel: "test1" }];
+    mockAuthenticated.value = true;
+
+    // Act
+    let state: ReturnType<typeof useUnifiedChatState>;
+    scope.run(() => {
+      state = useUnifiedChatState();
+    });
+
+    // Assert
+    expect(state!.unifiedChatState.value.showUnifiedChat).toBe(false);
+  });
+
+  it("shows unified chat when there are 2 or more total streams", () => {
+    // Arrange
+    mockStreams.value = [
+      { platform: "twitch", channel: "test1" },
+      { platform: "kick", channel: "test2" },
+    ];
+    mockAuthenticated.value = true;
+
+    // Act
+    let state: ReturnType<typeof useUnifiedChatState>;
+    scope.run(() => {
+      state = useUnifiedChatState();
+    });
+
+    // Assert
+    expect(state!.unifiedChatState.value.showUnifiedChat).toBe(true);
+  });
+
+  it("calculates active platforms and total readable correctly when authenticated", () => {
+    // Arrange
+    mockStreams.value = [
+      { platform: "twitch", channel: "test1" },
+      { platform: "twitch", channel: "test2" },
+      { platform: "kick", channel: "test3" },
+    ];
+    mockAuthenticated.value = true;
+
+    // Act
+    let state: ReturnType<typeof useUnifiedChatState>;
+    scope.run(() => {
+      state = useUnifiedChatState();
+    });
+
+    // Assert
+    expect(state!.unifiedChatState.value.activePlatforms).toEqual(["twitch", "kick"]);
+    expect(state!.unifiedChatState.value.totalReadable).toBe(3);
+    expect(state!.unifiedChatState.value.warningType).toBe("none");
+  });
+
+  it("does not count twitch as readable when unauthenticated", () => {
+    // Arrange
+    mockStreams.value = [
+      { platform: "twitch", channel: "test1" },
+      { platform: "twitch", channel: "test2" },
+      { platform: "kick", channel: "test3" },
+    ];
+    mockAuthenticated.value = false;
+
+    // Act
+    let state: ReturnType<typeof useUnifiedChatState>;
+    scope.run(() => {
+      state = useUnifiedChatState();
+    });
+
+    // Assert
+    expect(state!.unifiedChatState.value.activePlatforms).toEqual(["kick"]);
+    expect(state!.unifiedChatState.value.totalReadable).toBe(1);
+  });
+
+  it("shows full warning when only twitch streams exist and user is not authenticated", () => {
+    // Arrange
+    mockStreams.value = [
+      { platform: "twitch", channel: "test1" },
+      { platform: "twitch", channel: "test2" },
+    ];
+    mockAuthenticated.value = false;
+
+    // Act
+    let state: ReturnType<typeof useUnifiedChatState>;
+    scope.run(() => {
+      state = useUnifiedChatState();
+    });
+
+    // Assert
+    expect(state!.unifiedChatState.value.warningType).toBe("full");
+    expect(state!.unifiedChatState.value.warningMessage).toBe("chat.unified.warningTwitchLogin");
+  });
+
+  it("shows banner warning when twitch and kick streams exist and user is not authenticated", () => {
+    // Arrange
+    mockStreams.value = [
+      { platform: "twitch", channel: "test1" },
+      { platform: "kick", channel: "test2" },
+    ];
+    mockAuthenticated.value = false;
+
+    // Act
+    let state: ReturnType<typeof useUnifiedChatState>;
+    scope.run(() => {
+      state = useUnifiedChatState();
+    });
+
+    // Assert
+    expect(state!.unifiedChatState.value.warningType).toBe("banner");
+    expect(state!.unifiedChatState.value.warningMessage).toBe(
+      "chat.unified.warningTwitchLoginToMerge"
+    );
+  });
+
+  it("shows no warning when only kick streams exist regardless of auth", () => {
+    // Arrange
+    mockStreams.value = [
+      { platform: "kick", channel: "test1" },
+      { platform: "kick", channel: "test2" },
+    ];
+    mockAuthenticated.value = false; // Twitch not authenticated
+
+    // Act
+    let state: ReturnType<typeof useUnifiedChatState>;
+    scope.run(() => {
+      state = useUnifiedChatState();
+    });
+
+    // Assert
+    expect(state!.unifiedChatState.value.warningType).toBe("none");
+    expect(state!.unifiedChatState.value.warningMessage).toBe("");
+  });
+});

--- a/src/composables/useEmotes.ts
+++ b/src/composables/useEmotes.ts
@@ -37,7 +37,7 @@ interface BttvChannelResponse {
 
 type RawToken =
   | { type: "text"; content: string }
-  | { type: "twitch_emote"; content: string; code: string };
+  | { type: "emote"; content: string; code: string };
 
 const fetchTwitchId = async (username: string): Promise<string | null> => {
   try {
@@ -192,7 +192,7 @@ const _useEmotes = () => {
       if (rep.start > currentIndex) {
         rawTokens.push({ type: "text", content: text.substring(currentIndex, rep.start) });
       }
-      rawTokens.push({ type: "twitch_emote", content: rep.url, code: rep.code });
+      rawTokens.push({ type: "emote", content: rep.url, code: rep.code });
       currentIndex = rep.end + 1;
     }
 
@@ -207,7 +207,7 @@ const _useEmotes = () => {
     const channelMap = channelEmotes[channel];
 
     for (const rt of rawTokens) {
-      if (rt.type === "twitch_emote") {
+      if (rt.type === "emote") {
         tokens.push({ type: "emote", content: rt.content, code: rt.code });
         continue;
       }

--- a/src/composables/useEmotes.ts
+++ b/src/composables/useEmotes.ts
@@ -143,7 +143,7 @@ const _useEmotes = () => {
   ): ParsedToken[] => {
     const tokens: ParsedToken[] = [];
 
-    const twitchReplacements: { start: number; end: number; url: string; code: string }[] = [];
+    const emoteReplacements: { start: number; end: number; url: string; code: string }[] = [];
     if (twitchEmotesStr) {
       const emotes = twitchEmotesStr.split("/");
       for (const emote of emotes) {
@@ -158,7 +158,7 @@ const _useEmotes = () => {
           if (start < 0 || end >= text.length) continue;
 
           const code = text.substring(start, end + 1);
-          twitchReplacements.push({
+          emoteReplacements.push({
             start,
             end,
             code,
@@ -168,12 +168,27 @@ const _useEmotes = () => {
       }
     }
 
-    twitchReplacements.sort((a, b) => a.start - b.start);
+    const kickRegex = /\[emote:(\d+):([^\]]+)\]/g;
+    let match;
+    while ((match = kickRegex.exec(text)) !== null) {
+      const start = match.index;
+      const end = kickRegex.lastIndex - 1;
+      const id = match[1] || "";
+      const code = match[2] || "";
+      emoteReplacements.push({
+        start,
+        end,
+        code,
+        url: `https://files.kick.com/emotes/${id}/fullsize`,
+      });
+    }
+
+    emoteReplacements.sort((a, b) => a.start - b.start);
 
     let currentIndex = 0;
     const rawTokens: RawToken[] = [];
 
-    for (const rep of twitchReplacements) {
+    for (const rep of emoteReplacements) {
       if (rep.start > currentIndex) {
         rawTokens.push({ type: "text", content: text.substring(currentIndex, rep.start) });
       }

--- a/src/composables/useKickAuth.ts
+++ b/src/composables/useKickAuth.ts
@@ -20,18 +20,10 @@ const _useKickAuth = () => {
   let unlistenAuthChanged: UnlistenFn | null = null;
   let unlistenAuthError: UnlistenFn | null = null;
   let unlistenAuthUrl: UnlistenFn | null = null;
+  let initPromise: Promise<void> | null = null;
 
   async function init() {
     if (!isTauri()) return;
-
-    try {
-      const state = await invoke<KickAuthState>("kick_get_auth_state");
-      authenticated.value = state.authenticated;
-      username.value = state.username;
-    } catch {
-      authenticated.value = false;
-      username.value = null;
-    }
 
     if (!unlistenAuthChanged) {
       unlistenAuthChanged = await listen<KickAuthState>("kick-auth-changed", (event) => {
@@ -51,10 +43,30 @@ const _useKickAuth = () => {
         authUrl.value = event.payload;
       });
     }
+
+    try {
+      const state = await invoke<KickAuthState>("kick_get_auth_state");
+      authenticated.value = state.authenticated;
+      username.value = state.username;
+    } catch {
+      authenticated.value = false;
+      username.value = null;
+    }
+  }
+
+  function ensureInit() {
+    if (!initPromise) {
+      initPromise = init().catch((error) => {
+        initPromise = null;
+        throw error;
+      });
+    }
+    return initPromise;
   }
 
   async function startLogin() {
     if (!isTauri() || loading.value) return;
+    await ensureInit();
     loading.value = true;
     try {
       await invoke("kick_login");
@@ -76,6 +88,15 @@ const _useKickAuth = () => {
     }
   }
 
+  async function cancelLogin() {
+    if (!isTauri()) return;
+    try {
+      await invoke("kick_cancel_login");
+    } catch (e) {
+      console.error("Failed to cancel Kick auth flow:", e);
+    }
+  }
+
   onScopeDispose(() => {
     if (unlistenAuthChanged) unlistenAuthChanged();
     if (unlistenAuthError) unlistenAuthError();
@@ -83,7 +104,7 @@ const _useKickAuth = () => {
   });
 
   if (isTauri()) {
-    init().catch(console.error);
+    ensureInit().catch(console.error);
   }
 
   return {
@@ -92,6 +113,7 @@ const _useKickAuth = () => {
     loading,
     authUrl,
     startLogin,
+    cancelLogin,
     logout,
   };
 };

--- a/src/composables/useKickChat.ts
+++ b/src/composables/useKickChat.ts
@@ -17,6 +17,13 @@ export interface KickChatMessage {
 }
 
 const activeKickChannels = new Map<string, number>(); // slug -> chatroom_id
+const activeBroadcasters = new Map<string, number>(); // slug -> broadcaster_user_id
+
+export function __test_resetKickChatState() {
+  activeKickChannels.clear();
+  activeBroadcasters.clear();
+}
+
 const messages = ref<KickChatMessage[]>([]);
 const connectionState = ref<"connected" | "disconnected" | "reconnecting">("disconnected");
 
@@ -68,6 +75,7 @@ export function useKickChat(channelSlug: string) {
       const chatroomId = data.chatroom.id;
 
       activeKickChannels.set(channelSlug, chatroomId);
+      activeBroadcasters.set(channelSlug, data.user_id);
       await updateSubscriptions();
     } catch (e) {
       console.error("Failed to fetch Kick chatroom ID for", channelSlug, e);
@@ -87,12 +95,19 @@ export function useKickChat(channelSlug: string) {
   }
 
   function removeLastLocalMessage(username: string): string | null {
-    const idx = messages.value.findIndex(
-      (m) =>
+    let idx = -1;
+    for (let i = messages.value.length - 1; i >= 0; i--) {
+      const m = messages.value[i];
+      if (
+        m &&
         m.channel === channelSlug &&
         m.username.toLowerCase() === username.toLowerCase() &&
         m.isPending
-    );
+      ) {
+        idx = i;
+        break;
+      }
+    }
     if (idx !== -1) {
       const msg = messages.value[idx];
       if (!msg) return null;
@@ -100,6 +115,10 @@ export function useKickChat(channelSlug: string) {
       return msg.message;
     }
     return null;
+  }
+
+  function getBroadcasterUserId() {
+    return activeBroadcasters.get(channelSlug) ?? null;
   }
 
   function addLocalMessage(msg: KickChatMessage) {
@@ -113,5 +132,6 @@ export function useKickChat(channelSlug: string) {
     leaveChannel,
     removeLastLocalMessage,
     addLocalMessage,
+    getBroadcasterUserId,
   };
 }

--- a/src/composables/useKickChat.ts
+++ b/src/composables/useKickChat.ts
@@ -1,0 +1,117 @@
+import { ref } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+export interface KickChatMessage {
+  id: string;
+  channel: string;
+  username: string;
+  display_name: string;
+  message: string;
+  timestamp_ms: number;
+  color?: string;
+  badges: string[];
+  emotes?: string;
+  isPending?: boolean;
+  platform?: "kick";
+}
+
+const activeKickChannels = new Map<string, number>(); // slug -> chatroom_id
+const messages = ref<KickChatMessage[]>([]);
+const connectionState = ref<"connected" | "disconnected" | "reconnecting">("disconnected");
+
+let isListening = false;
+
+async function setupListeners() {
+  if (isListening) return;
+  isListening = true;
+
+  await listen<{ state: "connected" | "disconnected" | "reconnecting" }>(
+    "kick-connection-state",
+    (event) => {
+      connectionState.value = event.payload.state;
+    }
+  ).catch(console.error);
+
+  await listen<KickChatMessage>("kick-chat-message", (event) => {
+    const msg = event.payload;
+    msg.platform = "kick";
+
+    const pendingIdx = messages.value.findIndex(
+      (m) =>
+        m.isPending &&
+        m.channel === msg.channel &&
+        m.username.toLowerCase() === msg.username.toLowerCase() &&
+        m.message === msg.message
+    );
+    if (pendingIdx !== -1) {
+      messages.value.splice(pendingIdx, 1);
+    }
+
+    messages.value.push(msg);
+    if (messages.value.length > 500) {
+      messages.value.shift();
+    }
+  }).catch(console.error);
+}
+
+export function useKickChat(channelSlug: string) {
+  setupListeners();
+
+  async function joinChannel() {
+    if (activeKickChannels.has(channelSlug)) return;
+
+    try {
+      const res = await fetch(`https://kick.com/api/v1/channels/${channelSlug}`);
+      if (!res.ok) throw new Error("Channel not found");
+      const data = await res.json();
+      const chatroomId = data.chatroom.id;
+
+      activeKickChannels.set(channelSlug, chatroomId);
+      await updateSubscriptions();
+    } catch (e) {
+      console.error("Failed to fetch Kick chatroom ID for", channelSlug, e);
+    }
+  }
+
+  async function leaveChannel() {
+    if (activeKickChannels.has(channelSlug)) {
+      activeKickChannels.delete(channelSlug);
+      await updateSubscriptions();
+    }
+  }
+
+  async function updateSubscriptions() {
+    const channels = Array.from(activeKickChannels.entries()).map(([slug, id]) => [slug, id]);
+    await invoke("kick_set_channels", { channels });
+  }
+
+  function removeLastLocalMessage(username: string): string | null {
+    const idx = messages.value.findIndex(
+      (m) =>
+        m.channel === channelSlug &&
+        m.username.toLowerCase() === username.toLowerCase() &&
+        m.isPending
+    );
+    if (idx !== -1) {
+      const msg = messages.value[idx];
+      if (!msg) return null;
+      messages.value.splice(idx, 1);
+      return msg.message;
+    }
+    return null;
+  }
+
+  function addLocalMessage(msg: KickChatMessage) {
+    messages.value.push(msg);
+  }
+
+  return {
+    messages,
+    connectionState,
+    joinChannel,
+    leaveChannel,
+    removeLastLocalMessage,
+    addLocalMessage,
+  };
+}

--- a/src/composables/useTwitchAuth.ts
+++ b/src/composables/useTwitchAuth.ts
@@ -17,6 +17,23 @@ export interface DeviceFlowResponse {
   verification_uri: string;
 }
 
+async function cancelLogin() {
+  if (!isTauri()) return;
+  try {
+    await invoke("twitch_cancel_login");
+  } catch (e) {
+    console.error("Failed to cancel login", e);
+  }
+}
+
+async function logout() {
+  if (!isTauri()) return;
+  try {
+    await invoke("twitch_logout");
+  } catch (e) {
+    console.error("Failed to logout", e);
+  }
+}
 const _useTwitchAuth = () => {
   const authenticated = ref(false);
   const username = ref<string | null>(null);
@@ -64,24 +81,6 @@ const _useTwitchAuth = () => {
       return null;
     } finally {
       loading.value = false;
-    }
-  }
-
-  async function cancelLogin() {
-    if (!isTauri()) return;
-    try {
-      await invoke("twitch_cancel_login");
-    } catch (e) {
-      console.error("Failed to cancel Twitch auth flow:", e);
-    }
-  }
-
-  async function logout() {
-    if (!isTauri()) return;
-    try {
-      await invoke("twitch_logout");
-    } catch (e) {
-      console.error("Failed to logout from Twitch:", e);
     }
   }
 

--- a/src/composables/useUnifiedChat.ts
+++ b/src/composables/useUnifiedChat.ts
@@ -19,6 +19,7 @@ export interface UnifiedChatMessage {
   color: string | null;
   badges: string[];
   emotes: string | null;
+  platform?: "twitch" | "kick";
   isPending?: boolean;
 }
 
@@ -58,7 +59,12 @@ const _useUnifiedChat = () => {
     streams.value.filter((s) => s.platform === "twitch").map((s) => s.channel.toLowerCase())
   );
 
+  const kickChannels = computed(() =>
+    streams.value.filter((s) => s.platform === "kick").map((s) => s.channel.toLowerCase())
+  );
+
   let unlistenMessage: UnlistenFn | null = null;
+  let unlistenKickMessage: UnlistenFn | null = null;
   let unlistenState: UnlistenFn | null = null;
   let unlistenAuthExpired: UnlistenFn | null = null;
 
@@ -66,6 +72,7 @@ const _useUnifiedChat = () => {
     if (!isTauri()) return;
     try {
       const existing = await invoke<UnifiedChatMessage[]>("twitch_get_messages");
+      existing.forEach((m) => (m.platform = "twitch"));
       messages.value = existing.slice(-MAX_FRONTEND_MESSAGES);
     } catch {
       messages.value = [];
@@ -85,15 +92,25 @@ const _useUnifiedChat = () => {
     if (!isTauri() || !authenticated.value) return;
     try {
       await invoke("twitch_send_message", { channel, text });
-
-      // Optimistically add the message to the list to feel fast
-      // But Twitch IRC also reflects our own messages via WebSocket, so we might see it twice.
-      // Actually, standard Twitch IRC might not reflect our own messages unless we have echo-message tag enabled.
-      // For now, let's just let the Rust backend handle it and maybe we get it echoed, or we can push it optimistically.
-      // Since we don't have our own local badges and color readily available, let's not push optimistically yet
-      // to avoid weird UI glitches, or just push a minimal message if needed.
     } catch (e) {
-      console.error("[useUnifiedChat] failed to send message", e);
+      console.error("[useUnifiedChat] failed to send Twitch message", e);
+      throw e;
+    }
+  }
+
+  async function sendKickMessage(channelSlug: string, text: string) {
+    if (!isTauri()) return;
+    try {
+      // 1. Resolve Kick channel slug -> broadcaster user_id via Frontend (bypasses Cloudflare)
+      const res = await fetch(`https://kick.com/api/v1/channels/${channelSlug}`);
+      if (!res.ok) throw new Error(`Channel fetch failed: ${res.status}`);
+      const data = await res.json();
+      const userId = data.user_id;
+
+      // 2. Send authenticated message via Rust backend
+      await invoke("kick_send_message", { broadcasterUserId: userId, message: text });
+    } catch (e) {
+      console.error("[useUnifiedChat] failed to send Kick message", e);
       throw e;
     }
   }
@@ -115,6 +132,7 @@ const _useUnifiedChat = () => {
       "unified-chat-message",
       (event) => {
         const msg = event.payload;
+        msg.platform = "twitch";
 
         if (msg.id.startsWith("local-")) {
           msg.isPending = true;
@@ -122,6 +140,49 @@ const _useUnifiedChat = () => {
             const found = messages.value.find((m) => m && m.id === msg.id);
             if (found) found.isPending = false;
           }, 1000);
+        }
+
+        pendingMessages.push(msg);
+        if (!flushTimer) {
+          flushTimer = setTimeout(() => {
+            if (pendingMessages.length > 0) {
+              messages.value.push(...pendingMessages);
+              if (messages.value.length > MAX_FRONTEND_MESSAGES) {
+                messages.value.splice(0, messages.value.length - MAX_FRONTEND_MESSAGES);
+              }
+              pendingMessages = [];
+            }
+            flushTimer = null;
+          }, 50); // 50ms batching (20fps) to eliminate jitters
+        }
+      }
+    );
+
+    const localUnlistenKickMessage = await listen<UnifiedChatMessage>(
+      "kick-chat-message",
+      (event) => {
+        const msg = event.payload;
+        msg.platform = "kick";
+
+        if (msg.id.startsWith("local-")) {
+          msg.isPending = true;
+          setTimeout(() => {
+            const found = messages.value.find((m) => m && m.id === msg.id);
+            if (found) found.isPending = false;
+          }, 1000);
+        } else {
+          // De-duplicate local optimistic messages that were manually pushed by UnifiedChat.vue
+          const pendingIdx = messages.value.findIndex(
+            (m) =>
+              m.isPending &&
+              m.platform === "kick" &&
+              m.channel === msg.channel &&
+              m.username.toLowerCase() === msg.username.toLowerCase() &&
+              m.message === msg.message
+          );
+          if (pendingIdx !== -1) {
+            messages.value.splice(pendingIdx, 1);
+          }
         }
 
         pendingMessages.push(msg);
@@ -152,6 +213,7 @@ const _useUnifiedChat = () => {
     });
 
     unlistenMessage = localUnlistenMessage;
+    unlistenKickMessage = localUnlistenKickMessage;
     unlistenState = localUnlistenState;
     unlistenAuthExpired = localUnlistenAuthExpired;
   }
@@ -181,8 +243,33 @@ const _useUnifiedChat = () => {
     { deep: true, immediate: true }
   );
 
+  watch(
+    kickChannels,
+    (channels) => {
+      channels.forEach(async (channel) => {
+        if (!channelAvatars[channel]) {
+          try {
+            const res = await fetch(
+              `https://kick.com/api/v2/channels/${encodeURIComponent(channel)}`
+            );
+            if (res.ok) {
+              const data = await res.json();
+              if (data?.user?.profile_pic) {
+                channelAvatars[channel] = data.user.profile_pic;
+              }
+            }
+          } catch (e) {
+            console.error(`[useUnifiedChat] Failed to fetch avatar for Kick channel ${channel}`, e);
+          }
+        }
+      });
+    },
+    { deep: true, immediate: true }
+  );
+
   onScopeDispose(() => {
     unlistenMessage?.();
+    unlistenKickMessage?.();
     unlistenState?.();
     unlistenAuthExpired?.();
   });
@@ -206,7 +293,34 @@ const _useUnifiedChat = () => {
         m &&
         m.channel === channel &&
         m.username.toLowerCase() === currentUsername.toLowerCase() &&
-        m.isPending === true
+        m.isPending === true &&
+        m.platform === "twitch"
+      ) {
+        lastIdx = i;
+        break;
+      }
+    }
+
+    if (lastIdx !== -1) {
+      const removed = messages.value.splice(lastIdx, 1)[0];
+      if (removed) {
+        return removed.message;
+      }
+    }
+    return null;
+  }
+
+  function removeLastLocalKickMessage(channel: string, currentUsername: string): string | null {
+    // Same implementation but could differ if Kick uses different username casing rules
+    let lastIdx = -1;
+    for (let i = messages.value.length - 1; i >= 0; i--) {
+      const m = messages.value[i];
+      if (
+        m &&
+        m.channel.toLowerCase() === channel.toLowerCase() &&
+        m.username.toLowerCase() === currentUsername.toLowerCase() &&
+        m.isPending === true &&
+        m.platform === "kick"
       ) {
         lastIdx = i;
         break;
@@ -228,8 +342,11 @@ const _useUnifiedChat = () => {
     channelColor,
     channelAvatars,
     twitchChannels,
+    kickChannels,
     sendMessage,
+    sendKickMessage,
     removeLastLocalMessage,
+    removeLastLocalKickMessage,
   };
 };
 

--- a/src/composables/useUnifiedChatState.ts
+++ b/src/composables/useUnifiedChatState.ts
@@ -1,0 +1,53 @@
+import { computed } from "vue";
+import { createSharedComposable } from "@vueuse/core";
+import { useStreams } from "./useStreams";
+import { useTwitchAuth } from "./useTwitchAuth";
+
+const _useUnifiedChatState = () => {
+  const { streams } = useStreams();
+  const { authenticated } = useTwitchAuth();
+
+  const unifiedChatState = computed(() => {
+    const twitchStreams = streams.value.filter((s) => s.platform === "twitch");
+    const kickStreams = streams.value.filter((s) => s.platform === "kick");
+
+    const twitchCount = twitchStreams.length;
+    const kickCount = kickStreams.length;
+    const totalStreams = twitchCount + kickCount;
+
+    const twitchReadableCount = authenticated.value ? twitchCount : 0;
+    const kickReadableCount = kickCount;
+    // The Unified Chat feature appears when there are at least 2 streams active in the app.
+    // This allows the user to discover the feature and understand why it might not be working.
+    const showUnifiedChat = totalStreams >= 2;
+
+    const activePlatforms: ("twitch" | "kick")[] = [];
+    if (twitchReadableCount > 0) activePlatforms.push("twitch");
+    if (kickReadableCount > 0) activePlatforms.push("kick");
+
+    let warningMessage = "";
+    let warningType: "none" | "banner" | "full" = "none";
+
+    if (twitchCount > 0 && !authenticated.value) {
+      if (kickCount > 0) {
+        warningType = "banner";
+        warningMessage = "chat.unified.warningTwitchLoginToMerge";
+      } else {
+        warningType = "full";
+        warningMessage = "chat.unified.warningTwitchLogin";
+      }
+    }
+
+    return {
+      showUnifiedChat,
+      activePlatforms,
+      warningMessage,
+      warningType,
+      totalReadable: twitchReadableCount + kickReadableCount,
+    };
+  });
+
+  return { unifiedChatState };
+};
+
+export const useUnifiedChatState = createSharedComposable(_useUnifiedChatState);

--- a/src/i18n/locales/cn.json
+++ b/src/i18n/locales/cn.json
@@ -190,9 +190,8 @@
         "waiting": "等待授权中...",
         "cancel": "取消"
       },
-      "warningTwitchMissing": "Connect your Twitch account to enable Twitch chat.",
-      "warningTwitchLoginToMerge": "Connect your Twitch account to include Twitch chats in Unified Chat.",
-      "warningTwitchLogin": "Connect your Twitch account to enable Unified Chat."
+      "warningTwitchLoginToMerge": "连接您的Twitch帐号以在统一聊天中包含Twitch聊天。",
+      "warningTwitchLogin": "连接您的Twitch帐号以启用统一聊天。"
     },
     "loginPrompt": "登录以互动",
     "loginPromptTwitch": "连接您的 Twitch 帐户以在此频道中发送消息。",

--- a/src/i18n/locales/cn.json
+++ b/src/i18n/locales/cn.json
@@ -172,13 +172,13 @@
       "copied": "已复制！"
     },
     "unified": {
-      "selectorLabel": "Twitch 统一聊天",
+      "selectorLabel": "统一聊天",
       "connectTitle": "连接 Twitch",
       "connectHint": "登录以在单一聊天流中查看网格中所有 Twitch 频道的消息。",
       "connectButton": "连接",
       "reconnecting": "正在重新连接…",
-      "noTwitchStreams": "网格中没有 Twitch 直播。",
-      "noTwitchStreamsHint": "添加 Twitch 直播以在此查看消息。",
+      "noStreams": "网格中没有 Twitch 直播。",
+      "noStreamsHint": "添加 Twitch 直播以在此查看消息。",
       "disconnected": "聊天已断开。",
       "auth": {
         "expired": "授权码已过期。请重试。",
@@ -188,8 +188,15 @@
         "step2": "2. 输入此代码以关联您的账户",
         "waiting": "等待授权中...",
         "cancel": "取消"
-      }
-    }
+      },
+      "warningTwitchMissing": "Connect your Twitch account to enable Twitch chat.",
+      "warningTwitchLoginToMerge": "Connect your Twitch account to include Twitch chats in Unified Chat.",
+      "warningTwitchLogin": "Connect your Twitch account to enable Unified Chat."
+    },
+    "loginPrompt": "登录以互动",
+    "loginPromptTwitch": "连接您的 Twitch 帐户以在此频道中发送消息。",
+    "loginPromptKick": "连接您的 Kick 帐户以在此频道中发送消息。",
+    "connectAction": "连接"
   },
   "common": {
     "close": "关闭",

--- a/src/i18n/locales/cn.json
+++ b/src/i18n/locales/cn.json
@@ -52,7 +52,8 @@
       "openBrowser": "手动打开浏览器",
       "connected": "已连接",
       "disconnect": "断开连接",
-      "disconnected": "未连接"
+      "disconnected": "未连接",
+      "logout": "登出"
     },
     "backup": {
       "title": "数据与备份",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -190,9 +190,8 @@
         "waiting": "Warten auf Autorisierung...",
         "cancel": "Abbrechen"
       },
-      "warningTwitchMissing": "Connect your Twitch account to enable Twitch chat.",
-      "warningTwitchLoginToMerge": "Connect your Twitch account to include Twitch chats in Unified Chat.",
-      "warningTwitchLogin": "Connect your Twitch account to enable Unified Chat."
+      "warningTwitchLoginToMerge": "Verbinde dein Twitch-Konto, um Twitch-Chats im vereinheitlichten Chat einzuschließen.",
+      "warningTwitchLogin": "Verbinde dein Twitch-Konto, um den vereinheitlichten Chat zu aktivieren."
     },
     "loginPrompt": "Melden Sie sich an, um zu interagieren",
     "loginPromptTwitch": "Verbinden Sie Ihr Twitch-Konto, um Nachrichten in diesem Kanal zu senden.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -52,7 +52,8 @@
       "openBrowser": "Browser manuell öffnen",
       "connected": "Verbunden",
       "disconnect": "Trennen",
-      "disconnected": "Getrennt"
+      "disconnected": "Getrennt",
+      "logout": "Abmelden"
     },
     "backup": {
       "title": "Daten & Backup",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -172,13 +172,13 @@
       "copied": "Kopiert!"
     },
     "unified": {
-      "selectorLabel": "Einheitlicher Twitch-Chat",
+      "selectorLabel": "Einheitlicher Chat",
       "connectTitle": "Mit Twitch verbinden",
       "connectHint": "Melde dich an, um Nachrichten aller Twitch-Kanäle in deinem Raster in einem Feed zu sehen.",
       "connectButton": "Verbinden",
       "reconnecting": "Verbindung wird wiederhergestellt…",
-      "noTwitchStreams": "Keine Twitch-Streams im Raster.",
-      "noTwitchStreamsHint": "Füge einen Twitch-Stream hinzu, um Nachrichten hier zu sehen.",
+      "noStreams": "Keine Twitch-Streams im Raster.",
+      "noStreamsHint": "Füge einen Twitch-Stream hinzu, um Nachrichten hier zu sehen.",
       "disconnected": "Chat getrennt.",
       "auth": {
         "expired": "Der Autorisierungscode ist abgelaufen. Bitte versuche es erneut.",
@@ -188,8 +188,15 @@
         "step2": "2. Gib diesen Code ein, um dein Konto zu verknüpfen",
         "waiting": "Warten auf Autorisierung...",
         "cancel": "Abbrechen"
-      }
-    }
+      },
+      "warningTwitchMissing": "Connect your Twitch account to enable Twitch chat.",
+      "warningTwitchLoginToMerge": "Connect your Twitch account to include Twitch chats in Unified Chat.",
+      "warningTwitchLogin": "Connect your Twitch account to enable Unified Chat."
+    },
+    "loginPrompt": "Melden Sie sich an, um zu interagieren",
+    "loginPromptTwitch": "Verbinden Sie Ihr Twitch-Konto, um Nachrichten in diesem Kanal zu senden.",
+    "loginPromptKick": "Verbinden Sie Ihr Kick-Konto, um Nachrichten in diesem Kanal zu senden.",
+    "connectAction": "Verbinden"
   },
   "common": {
     "close": "Schließen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -190,7 +190,6 @@
         "waiting": "Waiting for authorization...",
         "cancel": "Cancel"
       },
-      "warningTwitchMissing": "Connect your Twitch account to enable Twitch chat.",
       "warningTwitchLoginToMerge": "Connect your Twitch account to include Twitch chats in Unified Chat.",
       "warningTwitchLogin": "Connect your Twitch account to enable Unified Chat."
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -172,13 +172,13 @@
       "copied": "Copied!"
     },
     "unified": {
-      "selectorLabel": "Unified Twitch Chat",
+      "selectorLabel": "Unified Chat",
       "connectTitle": "Connect with Twitch",
       "connectHint": "Sign in to see messages from all Twitch channels in your grid in a single feed.",
       "connectButton": "Connect",
       "reconnecting": "Reconnecting…",
-      "noTwitchStreams": "No Twitch streams in your grid.",
-      "noTwitchStreamsHint": "Add a Twitch stream to see messages here.",
+      "noStreams": "No streams in your grid.",
+      "noStreamsHint": "Add a stream to see messages here.",
       "disconnected": "Chat disconnected.",
       "auth": {
         "expired": "The authorization code has expired. Please try again.",
@@ -188,8 +188,15 @@
         "step2": "2. Enter this code to link your account",
         "waiting": "Waiting for authorization...",
         "cancel": "Cancel"
-      }
-    }
+      },
+      "warningTwitchMissing": "Connect your Twitch account to enable Twitch chat.",
+      "warningTwitchLoginToMerge": "Connect your Twitch account to include Twitch chats in Unified Chat.",
+      "warningTwitchLogin": "Connect your Twitch account to enable Unified Chat."
+    },
+    "loginPrompt": "Log in to interact",
+    "loginPromptTwitch": "Connect your Twitch account to send messages in this channel.",
+    "loginPromptKick": "Connect your Kick account to send messages in this channel.",
+    "connectAction": "Connect"
   },
   "common": {
     "close": "Close",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -52,7 +52,8 @@
       "openBrowser": "Open Browser Manually",
       "connected": "Connected",
       "disconnect": "Disconnect",
-      "disconnected": "Disconnected"
+      "disconnected": "Disconnected",
+      "logout": "Logout"
     },
     "help": {
       "title": "Help",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -52,7 +52,8 @@
       "openBrowser": "Abrir Navegador Manualmente",
       "connected": "Conectado",
       "disconnect": "Desconectar",
-      "disconnected": "Desconectado"
+      "disconnected": "Desconectado",
+      "logout": "Cerrar sesión"
     },
     "backup": {
       "title": "Datos y Copia de seguridad",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -190,7 +190,6 @@
         "waiting": "Esperando autorización...",
         "cancel": "Cancelar"
       },
-      "warningTwitchMissing": "Conecta tu cuenta de Twitch para habilitar el chat de Twitch.",
       "warningTwitchLoginToMerge": "Conecta tu cuenta de Twitch para incluir chats de Twitch en el Chat Unificado.",
       "warningTwitchLogin": "Conecta tu cuenta de Twitch para habilitar el Chat Unificado."
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -172,13 +172,13 @@
       "copied": "¡Copiado!"
     },
     "unified": {
-      "selectorLabel": "Chat Unificado de Twitch",
+      "selectorLabel": "Chat Unificado",
       "connectTitle": "Conectar con Twitch",
       "connectHint": "Inicia sesión para ver los mensajes de todos los canales de Twitch de tu cuadrícula en un solo feed.",
       "connectButton": "Conectar",
       "reconnecting": "Reconectando…",
-      "noTwitchStreams": "No hay streams de Twitch en tu cuadrícula.",
-      "noTwitchStreamsHint": "Añade un stream de Twitch para ver mensajes aquí.",
+      "noStreams": "No hay streams de Twitch en tu cuadrícula.",
+      "noStreamsHint": "Añade un stream de Twitch para ver mensajes aquí.",
       "disconnected": "Chat desconectado.",
       "auth": {
         "expired": "El código de autorización ha expirado. Por favor, inténtalo de nuevo.",
@@ -188,8 +188,15 @@
         "step2": "2. Ingresa este código para vincular tu cuenta",
         "waiting": "Esperando autorización...",
         "cancel": "Cancelar"
-      }
-    }
+      },
+      "warningTwitchMissing": "Conecta tu cuenta de Twitch para habilitar el chat de Twitch.",
+      "warningTwitchLoginToMerge": "Conecta tu cuenta de Twitch para incluir chats de Twitch en el Chat Unificado.",
+      "warningTwitchLogin": "Conecta tu cuenta de Twitch para habilitar el Chat Unificado."
+    },
+    "loginPrompt": "Inicia sesión para interactuar",
+    "loginPromptTwitch": "Conecta tu cuenta de Twitch para enviar mensajes en este canal.",
+    "loginPromptKick": "Conecta tu cuenta de Kick para enviar mensajes en este canal.",
+    "connectAction": "Conectar"
   },
   "common": {
     "close": "Cerrar",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -52,7 +52,8 @@
       "openBrowser": "Abrir Navegador Manualmente",
       "connected": "Conectado",
       "disconnect": "Desconectar",
-      "disconnected": "Desconectado"
+      "disconnected": "Desconectado",
+      "logout": "Sair"
     },
     "help": {
       "title": "Ajuda",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -172,13 +172,13 @@
       "copied": "Copiado!"
     },
     "unified": {
-      "selectorLabel": "Chat Unificado da Twitch",
+      "selectorLabel": "Chat Unificado",
       "connectTitle": "Conectar com a Twitch",
       "connectHint": "Entre com sua conta para ver mensagens de todos os canais Twitch da sua grade em um único feed.",
       "connectButton": "Conectar",
       "reconnecting": "Reconectando…",
-      "noTwitchStreams": "Nenhuma stream da Twitch na sua grade.",
-      "noTwitchStreamsHint": "Adicione uma stream da Twitch para ver mensagens aqui.",
+      "noStreams": "Nenhuma stream na sua grade.",
+      "noStreamsHint": "Adicione uma stream para ver mensagens aqui.",
       "disconnected": "Chat desconectado.",
       "auth": {
         "expired": "O código de autorização expirou. Por favor, tente novamente.",
@@ -188,8 +188,15 @@
         "step2": "2. Insira este código para vincular sua conta",
         "waiting": "Aguardando autorização...",
         "cancel": "Cancelar"
-      }
-    }
+      },
+      "warningTwitchMissing": "Conecte sua conta da Twitch para habilitar o chat da Twitch.",
+      "warningTwitchLoginToMerge": "Conecte sua conta da Twitch para incluir chats da Twitch no Chat Unificado.",
+      "warningTwitchLogin": "Conecte sua conta da Twitch para habilitar o Chat Unificado."
+    },
+    "loginPrompt": "Faça login para interagir",
+    "loginPromptTwitch": "Conecte sua conta da Twitch para enviar mensagens neste canal.",
+    "loginPromptKick": "Conecte sua conta da Kick para enviar mensagens neste canal.",
+    "connectAction": "Conectar"
   },
   "common": {
     "close": "Fechar",
@@ -243,7 +250,7 @@
     "finish": "Começar",
     "step1": {
       "title": "Adicionar Streams",
-      "description": "Clique no botão '+' no menu lateral ou pressione a tecla {key} para adicionar uma stream da Twitch, Kick ou YouTube."
+      "description": "Clique no botão '+' no menu lateral ou pressione a tecla {key} para adicionar uma stream, Kick ou YouTube."
     },
     "step2": {
       "title": "Selecionar Chat",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -190,7 +190,6 @@
         "waiting": "Aguardando autorização...",
         "cancel": "Cancelar"
       },
-      "warningTwitchMissing": "Conecte sua conta da Twitch para habilitar o chat da Twitch.",
       "warningTwitchLoginToMerge": "Conecte sua conta da Twitch para incluir chats da Twitch no Chat Unificado.",
       "warningTwitchLogin": "Conecte sua conta da Twitch para habilitar o Chat Unificado."
     },

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -52,7 +52,8 @@
       "openBrowser": "Открыть браузер вручную",
       "connected": "Подключено",
       "disconnect": "Отключить",
-      "disconnected": "Отключено"
+      "disconnected": "Отключено",
+      "logout": "Выйти"
     },
     "backup": {
       "title": "Данные и бэкап",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -190,9 +190,8 @@
         "waiting": "Ожидание авторизации...",
         "cancel": "Отмена"
       },
-      "warningTwitchMissing": "Connect your Twitch account to enable Twitch chat.",
-      "warningTwitchLoginToMerge": "Connect your Twitch account to include Twitch chats in Unified Chat.",
-      "warningTwitchLogin": "Connect your Twitch account to enable Unified Chat."
+      "warningTwitchLoginToMerge": "Подключите аккаунт Twitch, чтобы добавить чаты Twitch в Единый чат.",
+      "warningTwitchLogin": "Подключите аккаунт Twitch, чтобы включить Единый чат."
     },
     "loginPrompt": "Войдите, чтобы взаимодействовать",
     "loginPromptTwitch": "Подключите свою учетную запись Twitch, чтобы отправлять сообщения в этом канале.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -172,13 +172,13 @@
       "copied": "Скопировано!"
     },
     "unified": {
-      "selectorLabel": "Единый чат Twitch",
+      "selectorLabel": "Единый чат",
       "connectTitle": "Подключиться к Twitch",
       "connectHint": "Войдите, чтобы видеть сообщения из всех каналов Twitch в вашей сетке в едином ленте.",
       "connectButton": "Подключиться",
       "reconnecting": "Переподключение…",
-      "noTwitchStreams": "Нет потоков Twitch в вашей сетке.",
-      "noTwitchStreamsHint": "Добавьте поток Twitch, чтобы видеть сообщения здесь.",
+      "noStreams": "Нет потоков Twitch в вашей сетке.",
+      "noStreamsHint": "Добавьте поток Twitch, чтобы видеть сообщения здесь.",
       "disconnected": "Чат отключён.",
       "auth": {
         "expired": "Срок действия кода авторизации истек. Пожалуйста, попробуйте еще раз.",
@@ -188,8 +188,15 @@
         "step2": "2. Введите этот код, чтобы привязать ваш аккаунт",
         "waiting": "Ожидание авторизации...",
         "cancel": "Отмена"
-      }
-    }
+      },
+      "warningTwitchMissing": "Connect your Twitch account to enable Twitch chat.",
+      "warningTwitchLoginToMerge": "Connect your Twitch account to include Twitch chats in Unified Chat.",
+      "warningTwitchLogin": "Connect your Twitch account to enable Unified Chat."
+    },
+    "loginPrompt": "Войдите, чтобы взаимодействовать",
+    "loginPromptTwitch": "Подключите свою учетную запись Twitch, чтобы отправлять сообщения в этом канале.",
+    "loginPromptKick": "Подключите свою учетную запись Kick, чтобы отправлять сообщения в этом канале.",
+    "connectAction": "Подключить"
   },
   "common": {
     "close": "Закрыть",


### PR DESCRIPTION
**Description**: This PR introduces the highly anticipated native chat integration for Kick, including reading live messages, sending messages to Kick channels directly from the app, and the new "Super Unified Chat" that seamlessly aggregates both Twitch and Kick streams into a single feed.

**Key changes**:
- **Kick Native Chat:** Added `KickNativeChat.vue` with full i18n support, allowing users to actively participate in Kick channels directly from the application's sidebar.
- **Pusher WebSockets & Chat API:** Built a robust Rust backend client that connects to Kick's Pusher-based WebSockets. The frontend uses `useKickChat` to dynamically discover the channel's numerical `chatroom_id` via HTTP lazy-loading before establishing the socket.
- **Optimistic UI & Rollbacks:** Sending messages is now instantaneous for the user. Messages are optimistically injected into the chat with an `isPending=true` state. If the backend encounters an error, the frontend safely rolls back the message, restores the user's input, and displays an error toast without blocking the UX.
- **Super Unified Chat (`useUnifiedChat`):** Completely refactored the old Twitch-only unified chat into a robust multi-platform aggregator. It now multiplexes Twitch IRC and Kick WebSockets, intelligently combining them into one central feed whenever 2 or more streams are active.
- **Smart State Warnings:** The unified chat dynamically evaluates the active streams (`useUnifiedChatState.ts`) and displays localized banner or full-screen warnings instructing the user to log in if they want to merge unauthenticated platforms.
- **Comprehensive Testing:** Created exhaustive Vitest suites for the new composables (`useKickChat`, `useUnifiedChatState`), enforcing the AAA pattern, isolating `window` events, and mocking Tauri's IPC event queue and microtasks to achieve 100% test passing.

**Notes**:
- The backend multiplexes Twitch's single IRC connection alongside multiple dedicated Kick WebSocket connections, funneling everything into unified frontend IPC events.
- Also includes minor stability patches from previous CodeRabbit reviews (such as `.env` tracking fixes in `build.rs`, safer OAuth callback parsing, and CSRF `state` validation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kick chat support, including sending messages, chat connection handling, and unified multi-platform chat.
  * Added a unified chat view that can show Twitch and Kick messages together, with platform icons and improved login prompts.

* **Bug Fixes**
  * Improved stream selection behavior when the active channel disappears.
  * Fixed Kick login and logout flows, including canceling login and preserving valid authentication state.
  * Added better message parsing for Kick emotes and safer import handling.

* **Documentation**
  * Updated localized UI text for unified chat, account status, and logout actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->