### PR TITLE
feat: drag and drop stream reordering

### DIFF
--- a/src/components/main/StreamGrid.vue
+++ b/src/components/main/StreamGrid.vue
@@ -4,14 +4,29 @@ import TwitchStream from "@/components/stream/TwitchStream.vue";
 import YoutubeStream from "@/components/stream/YoutubeStream.vue";
 import CustomStream from "@/components/stream/CustomStream.vue";
 import TranscriptionOverlay from "./TranscriptionOverlay.vue";
-import { useStreams } from "@/composables/useStreams";
+import { GripVertical } from "lucide-vue-next";
+import { useDragAndDrop } from "@/composables/useDragAndDrop";
+import { useStreams, type Stream } from "@/composables/useStreams";
 import { useFocusedStream } from "@/composables/useFocusedStream";
 import { usePreferences } from "@/composables/usePreferences";
-import { computed, watch, nextTick } from "vue";
+import { computed, watch, nextTick, ref } from "vue";
 
 const { streams, gridClass, isLeaving, getStreamKey } = useStreams();
 const { focusedStreamId, isFocused } = useFocusedStream();
+const { draggingId, overId, isDragging, onMouseDown, onMouseEnter, onMouseLeave, onMouseUp, onGlobalMouseUp } =
+  useDragAndDrop();
 const { setSelectedChat } = usePreferences();
+
+const domStreams = ref<Stream[]>([]);
+
+watch(streams, (newStreams) => {
+  domStreams.value = domStreams.value.filter(ds => newStreams.some(s => s.id === ds.id));
+  newStreams.forEach(s => {
+    if (!domStreams.value.some(ds => ds.id === s.id)) {
+      domStreams.value.push(s);
+    }
+  });
+}, { deep: true, immediate: true });
 
 // auto-select the chat of the focused stream
 watch(focusedStreamId, async (newId) => {
@@ -101,44 +116,77 @@ const containerStyle = computed(() => {
  * Normal mode     → empty object, Tailwind handles it.
  */
 const getStreamStyle = (streamId: string) => {
-  if (!focusedStreamId.value) return {};
+  const index = streams.value.findIndex(s => s.id === streamId);
+  const baseStyle = { order: index };
+
+  if (!focusedStreamId.value) return baseStyle;
   if (isFocused(streamId)) {
     return {
+      ...baseStyle,
       gridColumn: "2",
       gridRow: `1 / ${nonFocusedCount.value + 1}`,
     };
   }
-  return { gridColumn: "1" };
+  return { ...baseStyle, gridColumn: "1" };
 };
 
 /**
  * Returns extra classes for each stream cell in normal (non-focus) mode.
  * Handles the 3-stream special case where the last item spans 2 columns.
  */
-const getStreamClass = (index: number) => {
+const getStreamClass = (streamId: string) => {
   if (focusedStreamId.value) return "";
+  const index = streams.value.findIndex(s => s.id === streamId);
   return streams.value.length === 3 && index === 2 ? "col-span-2 justify-self-center w-1/2" : "";
 };
 </script>
 
 <template>
   <div
-    class="h-full overflow-hidden"
-    :class="!focusedStreamId ? ['grid', gridClass, 'gap-0.5'] : ''"
-    :style="containerStyle"
-  >
+      class="h-full overflow-hidden select-none"
+      :class="!focusedStreamId ? ['grid', gridClass, 'gap-0.5'] : ''"
+      :style="containerStyle"
+      @mouseup="onGlobalMouseUp"
+    >
     <div
-      v-for="(stream, index) in streams"
+      v-for="stream in domStreams"
       :key="getStreamKey(stream)"
       :data-stream-id="stream.id"
       :data-testid="`stream-item-${stream.channel}`"
       :style="getStreamStyle(stream.id)"
       :class="[
-        getStreamClass(index),
-        'min-h-0 min-w-0 stream-item overflow-hidden rounded-sm relative',
+        getStreamClass(stream.id),
+        'min-h-0 min-w-0 stream-item overflow-hidden rounded-sm relative group/grid-item',
         isLeaving(stream.id) ? 'stream-leaving' : '',
+        draggingId === stream.id ? 'opacity-50' : '',
       ]"
+      @mouseenter="onMouseEnter(stream.id)"
+      @mouseleave="onMouseLeave"
+      @mouseup="onMouseUp(stream.id)"
     >
+      <div
+        v-if="isDragging"
+        :class="[
+          'absolute inset-0 z-40 transition-colors',
+          overId === stream.id && draggingId !== stream.id
+            ? 'bg-blue-500/10 ring-2 ring-blue-500'
+            : 'bg-transparent',
+        ]"
+      />
+
+      <div
+        :class="[
+          'absolute z-50 opacity-0 group-hover/grid-item:opacity-100 transition-opacity cursor-grab p-1.5 rounded-md bg-black/60 border border-white/10 hover:bg-black/80 text-white/50 hover:text-white',
+          focusedStreamId && !isFocused(stream.id)
+            ? 'top-1 left-1/2 -translate-x-1/2 scale-90'
+            : 'top-3 left-1/2 -translate-x-1/2',
+          isDragging ? 'cursor-grabbing' : '',
+        ]"
+        @mousedown.stop="onMouseDown(stream.id)"
+      >
+        <GripVertical class="size-4 pointer-events-none" />
+      </div>
+
       <TranscriptionOverlay v-if="isFocused(stream.id) || streams.length === 1" />
 
       <KickStream

--- a/src/components/main/StreamGrid.vue
+++ b/src/components/main/StreamGrid.vue
@@ -10,12 +10,15 @@ import { useStreams, type Stream } from "@/composables/useStreams";
 import { useFocusedStream } from "@/composables/useFocusedStream";
 import { usePreferences } from "@/composables/usePreferences";
 import { computed, watch, nextTick, ref } from "vue";
+import { useEventListener } from "@vueuse/core";
 
 const { streams, gridClass, isLeaving, getStreamKey } = useStreams();
 const { focusedStreamId, isFocused } = useFocusedStream();
 const { draggingId, overId, isDragging, onMouseDown, onMouseEnter, onMouseLeave, onMouseUp, onGlobalMouseUp } =
   useDragAndDrop();
 const { setSelectedChat } = usePreferences();
+
+useEventListener(window, "mouseup", onGlobalMouseUp);
 
 const domStreams = ref<Stream[]>([]);
 
@@ -121,10 +124,11 @@ const getStreamStyle = (streamId: string) => {
 
   if (!focusedStreamId.value) return baseStyle;
   if (isFocused(streamId)) {
+    const rows = Math.max(nonFocusedCount.value, 1);
     return {
       ...baseStyle,
       gridColumn: "2",
-      gridRow: `1 / ${nonFocusedCount.value + 1}`,
+      gridRow: `1 / ${rows + 1}`,
     };
   }
   return { ...baseStyle, gridColumn: "1" };
@@ -142,11 +146,10 @@ const getStreamClass = (streamId: string) => {
 </script>
 
 <template>
-  <div
+    <div
       class="h-full overflow-hidden select-none"
       :class="!focusedStreamId ? ['grid', gridClass, 'gap-0.5'] : ''"
       :style="containerStyle"
-      @mouseup="onGlobalMouseUp"
     >
     <div
       v-for="stream in domStreams"

--- a/src/composables/__tests__/useDragAndDrop.spec.ts
+++ b/src/composables/__tests__/useDragAndDrop.spec.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { ref } from "vue";
+import { useDragAndDrop } from "../useDragAndDrop";
+import type { Stream } from "../useStreams";
+
+const mockStreamsRef = ref<Stream[]>([]);
+const mockFocusedStreamIdRef = ref<string | null>(null);
+
+vi.mock("../useStreams", () => ({
+  useStreams: () => ({
+    streams: mockStreamsRef,
+  }),
+}));
+
+vi.mock("../useFocusedStream", () => ({
+  useFocusedStream: () => ({
+    focusedStreamId: mockFocusedStreamIdRef,
+  }),
+}));
+
+const mockStreams: Stream[] = [
+  { id: "stream-1", channel: "gaules", platform: "twitch" },
+  { id: "stream-2", channel: "coringa", platform: "twitch" },
+  { id: "stream-3", channel: "alanzoka", platform: "twitch" },
+];
+
+describe("useDragAndDrop unit tests", () => {
+  let sut: ReturnType<typeof useDragAndDrop>;
+
+  beforeEach(() => {
+    sut = useDragAndDrop();
+
+    // Arrange: Reset mocked state
+    mockStreamsRef.value = [...mockStreams];
+    mockFocusedStreamIdRef.value = null;
+    sut.onGlobalMouseUp();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Mouse Events - Drag Start", () => {
+    it("should set draggingId on mousedown", () => {
+      // Act
+      sut.onMouseDown("stream-1");
+
+      // Assert
+      expect(sut.draggingId.value).toBe("stream-1");
+      expect(sut.isDragging.value).toBe(true);
+    });
+  });
+
+  describe("Mouse Events - Hover", () => {
+    it("should set overId on mouseenter if dragging", () => {
+      // Arrange
+      sut.onMouseDown("stream-1");
+
+      // Act
+      sut.onMouseEnter("stream-2");
+
+      // Assert
+      expect(sut.overId.value).toBe("stream-2");
+    });
+
+    it("should not set overId on mouseenter if not dragging", () => {
+      // Act
+      sut.onMouseEnter("stream-2");
+
+      // Assert
+      expect(sut.overId.value).toBeNull();
+    });
+
+    it("should clear overId on mouseleave", () => {
+      // Arrange
+      sut.onMouseDown("stream-1");
+      sut.onMouseEnter("stream-2");
+
+      // Act
+      sut.onMouseLeave();
+
+      // Assert
+      expect(sut.overId.value).toBeNull();
+    });
+  });
+
+  describe("Mouse Events - Drop (mouseup)", () => {
+    it("should do nothing if mouseup when not dragging", () => {
+      // Act
+      sut.onMouseUp("stream-2");
+
+      // Assert
+      expect(mockStreamsRef.value).toEqual(mockStreams);
+    });
+
+    it("should do nothing if mouseup on self", () => {
+      // Arrange
+      sut.onMouseDown("stream-1");
+      sut.onMouseEnter("stream-1");
+
+      // Act
+      sut.onMouseUp("stream-1");
+
+      // Assert
+      expect(mockStreamsRef.value).toEqual(mockStreams);
+      expect(sut.draggingId.value).toBeNull();
+    });
+
+    it("should do nothing if overId is null when mouseup fires", () => {
+      // Arrange
+      sut.onMouseDown("stream-1");
+
+      // Act - mouseup without entering another stream
+      sut.onMouseUp("stream-1");
+
+      // Assert
+      expect(mockStreamsRef.value).toEqual(mockStreams);
+    });
+
+    it("should swap two streams when mouseup on a valid target", () => {
+      // Arrange
+      sut.onMouseDown("stream-1");
+      sut.onMouseEnter("stream-3");
+
+      // Act
+      sut.onMouseUp("stream-3");
+
+      // Assert
+      const streams = mockStreamsRef.value;
+      expect(streams[0]!.id).toBe("stream-3");
+      expect(streams[1]!.id).toBe("stream-2");
+      expect(streams[2]!.id).toBe("stream-1");
+      expect(sut.draggingId.value).toBeNull();
+    });
+
+    it("should swap focusedStreamId if the dragged stream was focused", () => {
+      // Arrange
+      mockFocusedStreamIdRef.value = "stream-1";
+      sut.onMouseDown("stream-1");
+      sut.onMouseEnter("stream-2");
+
+      // Act
+      sut.onMouseUp("stream-2");
+
+      // Assert
+      expect(mockFocusedStreamIdRef.value).toBe("stream-2");
+      expect(mockStreamsRef.value[0]!.id).toBe("stream-2");
+      expect(mockStreamsRef.value[1]!.id).toBe("stream-1");
+    });
+
+    it("should swap focusedStreamId if the target stream was focused", () => {
+      // Arrange
+      mockFocusedStreamIdRef.value = "stream-2";
+      sut.onMouseDown("stream-1");
+      sut.onMouseEnter("stream-2");
+
+      // Act
+      sut.onMouseUp("stream-2");
+
+      // Assert
+      expect(mockFocusedStreamIdRef.value).toBe("stream-1");
+      expect(mockStreamsRef.value[0]!.id).toBe("stream-2");
+      expect(mockStreamsRef.value[1]!.id).toBe("stream-1");
+    });
+
+    it("should not touch focusedStreamId if neither dragged nor target were focused", () => {
+      // Arrange
+      mockFocusedStreamIdRef.value = "stream-3";
+      sut.onMouseDown("stream-1");
+      sut.onMouseEnter("stream-2");
+
+      // Act
+      sut.onMouseUp("stream-2");
+
+      // Assert
+      expect(mockFocusedStreamIdRef.value).toBe("stream-3");
+    });
+  });
+
+  describe("Global mouseup cleanup", () => {
+    it("should clear dragging state on global mouseup", () => {
+      // Arrange
+      sut.onMouseDown("stream-1");
+      sut.onMouseEnter("stream-2");
+
+      // Act
+      sut.onGlobalMouseUp();
+
+      // Assert
+      expect(sut.draggingId.value).toBeNull();
+      expect(sut.overId.value).toBeNull();
+      expect(sut.isDragging.value).toBe(false);
+    });
+  });
+});

--- a/src/composables/useDragAndDrop.ts
+++ b/src/composables/useDragAndDrop.ts
@@ -1,0 +1,77 @@
+import { ref, computed } from "vue";
+import { createSharedComposable } from "@vueuse/core";
+import { useStreams, type Stream } from "./useStreams";
+import { useFocusedStream } from "./useFocusedStream";
+
+const _useDragAndDrop = () => {
+  const draggingId = ref<string | null>(null);
+  const overId = ref<string | null>(null);
+
+  const { streams } = useStreams();
+  const { focusedStreamId } = useFocusedStream();
+
+  const isDragging = computed(() => draggingId.value !== null);
+
+  const swapStreams = (targetId: string) => {
+    if (draggingId.value === null || draggingId.value === targetId) return;
+
+    const fromIndex = streams.value.findIndex((s) => s.id === draggingId.value);
+    const toIndex = streams.value.findIndex((s) => s.id === targetId);
+
+    if (fromIndex === -1 || toIndex === -1) return;
+
+    const draggedStream = streams.value[fromIndex] as Stream;
+    const targetStream = streams.value[toIndex] as Stream;
+
+    const next = [...streams.value];
+    next[fromIndex] = targetStream;
+    next[toIndex] = draggedStream;
+    streams.value = next;
+
+    if (focusedStreamId.value === draggedStream.id) {
+      focusedStreamId.value = targetStream.id;
+    } else if (focusedStreamId.value === targetStream.id) {
+      focusedStreamId.value = draggedStream.id;
+    }
+  };
+
+  const onMouseDown = (id: string) => {
+    draggingId.value = id;
+  };
+
+  const onMouseEnter = (id: string) => {
+    if (draggingId.value === null) return;
+    overId.value = id;
+  };
+
+  const onMouseLeave = () => {
+    if (draggingId.value === null) return;
+    overId.value = null;
+  };
+
+  const onMouseUp = (targetId: string) => {
+    if (draggingId.value !== null && overId.value !== null) {
+      swapStreams(targetId);
+    }
+    draggingId.value = null;
+    overId.value = null;
+  };
+
+  const onGlobalMouseUp = () => {
+    draggingId.value = null;
+    overId.value = null;
+  };
+
+  return {
+    draggingId,
+    overId,
+    isDragging,
+    onMouseDown,
+    onMouseEnter,
+    onMouseLeave,
+    onMouseUp,
+    onGlobalMouseUp,
+  };
+};
+
+export const useDragAndDrop = createSharedComposable(_useDragAndDrop);


### PR DESCRIPTION
**Description**: 
Adds drag-and-drop to reorder streams in the grid. I used CSS `order` to move the streams visually instead of modifying the Vue array directly. This prevents the iframes from reloading when you swap positions, keeping the video and chat active.

**Key Changes**:
- Added `useDragAndDrop` to handle the drag state.
- Changed `StreamGrid.vue` to use a stable array and dynamic CSS `order`.
- Built the drag logic with raw mouse events (`mousedown`, `mouseenter`, `mouseup`) instead of the HTML5 API. WebView2 (Tauri) blocks native HTML5 drag events if `user-select: none` is set, and its file drop listener intercepts everything anyway. Mouse events bypass all of this.
- Added unit tests for the composable.

**Notes**:
- I added a transparent overlay (`z-index: 40`) that appears while dragging so the cross-origin iframes don't swallow the mouse events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support for stream tiles, including hover, drag, and drop interactions.
  * Introduced a visible drag handle and drag-state styling for easier reordering.
  * Improved stream layout behavior for focused and non-focused streams in grid mode.

* **Bug Fixes**
  * Kept stream focus aligned when items are moved.
  * Improved layout handling so stream positions stay consistent during updates.

* **Tests**
  * Added unit coverage for drag start, hover, drop, swap behavior, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->