### PR TITLE
feat: add left sidebar for live followed channels

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,13 +3,16 @@ use tauri::tray::TrayIconBuilder;
 use tauri::window::Color;
 use tauri::{Emitter, Manager};
 
+mod models;
+
 mod audio;
 use audio::transcriber::TranscriptionState;
 
 mod twitch;
 use twitch::commands::{
-    twitch_cancel_login, twitch_get_auth_state, twitch_get_connection_state, twitch_get_messages,
-    twitch_login, twitch_logout, twitch_send_message, twitch_set_channels,
+    twitch_cancel_login, twitch_get_auth_state, twitch_get_connection_state,
+    twitch_get_followed_streams, twitch_get_messages, twitch_login, twitch_logout,
+    twitch_send_message, twitch_set_channels,
 };
 use twitch::state::TwitchState;
 
@@ -133,6 +136,7 @@ pub fn run() {
             kick_get_auth_state,
             kick_send_message,
             kick_set_channels,
+            twitch_get_followed_streams,
         ])
         .setup(move |app| {
             app.manage(TranscriptionState(std::sync::Mutex::new(None)));

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FollowedChannel {
+    pub id: String,
+    pub platform: String,
+    pub display_name: String,
+    pub avatar_url: String,
+    pub is_live: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub viewer_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub game: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thumbnail_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}

--- a/src-tauri/src/twitch/commands.rs
+++ b/src-tauri/src/twitch/commands.rs
@@ -305,7 +305,23 @@ pub async fn twitch_get_followed_streams(
         .build()
         .map_err(TwitchError::Http)?;
 
-    let auth = try_refresh_if_needed(&app, auth, &state, &http).await?;
+    let auth = match try_refresh_if_needed(&app, auth, &state, &http).await {
+        Ok(auth) => auth,
+        Err(TwitchError::TokenRefreshFailed) => {
+            *state.auth.lock().await = None;
+            oauth::clear_auth(&app);
+            let _ = app.emit("twitch-auth-expired", ());
+            let _ = app.emit(
+                "twitch-auth-changed",
+                super::state::AuthState {
+                    authenticated: false,
+                    username: None,
+                },
+            );
+            return Err(TwitchError::TokenRefreshFailed);
+        }
+        Err(e) => return Err(e),
+    };
 
     let streams_url = format!(
         "https://api.twitch.tv/helix/streams/followed?user_id={}&first=100",
@@ -331,9 +347,7 @@ pub async fn twitch_get_followed_streams(
             .map_err(TwitchError::Http)?;
 
         if !res.status().is_success() {
-            if res.status() == reqwest::StatusCode::UNAUTHORIZED
-                || res.status() == reqwest::StatusCode::FORBIDDEN
-            {
+            if res.status() == reqwest::StatusCode::UNAUTHORIZED {
                 *state.auth.lock().await = None;
                 oauth::clear_auth(&app);
                 let _ = app.emit("twitch-auth-expired", ());

--- a/src-tauri/src/twitch/commands.rs
+++ b/src-tauri/src/twitch/commands.rs
@@ -1,3 +1,5 @@
+use crate::models::FollowedChannel;
+use serde_json::Value;
 use std::collections::HashSet;
 
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -282,4 +284,200 @@ async fn try_refresh_if_needed(
 
 pub fn init_stored_auth(app: &AppHandle) -> Option<TwitchAuthInfo> {
     oauth::load_auth(app)
+}
+
+#[tauri::command]
+pub async fn twitch_get_followed_streams(
+    app: AppHandle,
+    state: State<'_, TwitchState>,
+) -> Result<Vec<FollowedChannel>, TwitchError> {
+    let auth = {
+        let auth_guard = state.auth.lock().await;
+        auth_guard.clone()
+    };
+
+    let auth =
+        auth.ok_or_else(|| TwitchError::OAuth("Not authenticated with Twitch".to_string()))?;
+
+    let http = reqwest::Client::builder()
+        .use_rustls_tls()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(TwitchError::Http)?;
+
+    let auth = try_refresh_if_needed(&app, auth, &state, &http).await?;
+
+    let streams_url = format!(
+        "https://api.twitch.tv/helix/streams/followed?user_id={}&first=100",
+        auth.user_id
+    );
+
+    let mut live_streams = Vec::new();
+    let mut after = String::new();
+
+    loop {
+        let url = if after.is_empty() {
+            streams_url.clone()
+        } else {
+            format!("{}&after={}", streams_url, after)
+        };
+
+        let res = http
+            .get(&url)
+            .bearer_auth(&auth.access_token)
+            .header("Client-Id", super::oauth::CLIENT_ID)
+            .send()
+            .await
+            .map_err(TwitchError::Http)?;
+
+        if !res.status().is_success() {
+            if res.status() == reqwest::StatusCode::UNAUTHORIZED
+                || res.status() == reqwest::StatusCode::FORBIDDEN
+            {
+                *state.auth.lock().await = None;
+                oauth::clear_auth(&app);
+                let _ = app.emit("twitch-auth-expired", ());
+                let _ = app.emit(
+                    "twitch-auth-changed",
+                    super::state::AuthState {
+                        authenticated: false,
+                        username: None,
+                    },
+                );
+            }
+            return Err(TwitchError::OAuth(format!(
+                "Failed to fetch streams: {}",
+                res.status()
+            )));
+        }
+
+        let json: Value = res.json().await.map_err(TwitchError::Http)?;
+
+        if let Some(data) = json.get("data").and_then(|d| d.as_array()) {
+            if data.is_empty() {
+                break;
+            }
+            for item in data {
+                live_streams.push(item.clone());
+            }
+        } else {
+            break;
+        }
+
+        if let Some(cursor) = json
+            .get("pagination")
+            .and_then(|p| p.get("cursor"))
+            .and_then(|c| c.as_str())
+        {
+            after = cursor.to_string();
+        } else {
+            break;
+        }
+    }
+
+    let mut avatars = std::collections::HashMap::new();
+    for chunk in live_streams.chunks(100) {
+        let mut users_url = "https://api.twitch.tv/helix/users?".to_string();
+        for (i, item) in chunk.iter().enumerate() {
+            if let Some(user_id) = item.get("user_id").and_then(|s| s.as_str()) {
+                if i > 0 {
+                    users_url.push('&');
+                }
+                users_url.push_str(&format!("id={}", user_id));
+            }
+        }
+
+        if users_url.ends_with('?') {
+            continue;
+        }
+
+        let res = http
+            .get(&users_url)
+            .bearer_auth(&auth.access_token)
+            .header("Client-Id", super::oauth::CLIENT_ID)
+            .send()
+            .await;
+
+        if let Ok(r) = res {
+            if r.status().is_success() {
+                if let Ok(json) = r.json::<Value>().await {
+                    if let Some(data) = json.get("data").and_then(|d| d.as_array()) {
+                        for item in data {
+                            if let (Some(id), Some(avatar)) = (
+                                item.get("id").and_then(|s| s.as_str()),
+                                item.get("profile_image_url").and_then(|s| s.as_str()),
+                            ) {
+                                avatars.insert(id.to_string(), avatar.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut result = Vec::new();
+    for live_info in live_streams {
+        let id = live_info
+            .get("user_id")
+            .and_then(|s| s.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let name = live_info
+            .get("user_name")
+            .and_then(|s| s.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let login = live_info
+            .get("user_login")
+            .and_then(|s| s.as_str())
+            .unwrap_or_default()
+            .to_string();
+
+        let is_live = true;
+        let viewer_count = live_info.get("viewer_count").and_then(|v| v.as_u64());
+        let game = live_info
+            .get("game_name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let mut thumbnail_url = live_info
+            .get("thumbnail_url")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        if let Some(url) = &mut thumbnail_url {
+            *url = url.replace("{width}", "320").replace("{height}", "180");
+        }
+
+        let title = live_info
+            .get("title")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let avatar_url = avatars.get(&id).cloned().unwrap_or_default();
+
+        result.push(FollowedChannel {
+            id: login,
+            platform: "twitch".to_string(),
+            display_name: name,
+            avatar_url,
+            is_live,
+            viewer_count,
+            game,
+            thumbnail_url,
+            title,
+        });
+    }
+
+    result.sort_by(|a, b| {
+        b.viewer_count
+            .unwrap_or(0)
+            .cmp(&a.viewer_count.unwrap_or(0))
+            .then_with(|| {
+                a.display_name
+                    .to_lowercase()
+                    .cmp(&b.display_name.to_lowercase())
+            })
+    });
+
+    Ok(result)
 }

--- a/src-tauri/src/twitch/oauth.rs
+++ b/src-tauri/src/twitch/oauth.rs
@@ -5,7 +5,7 @@ use super::error::TwitchError;
 use super::state::TwitchAuthInfo;
 
 pub const CLIENT_ID: &str = "y0twwqcd7k38sf5587sxoi5ca9ghid";
-const SCOPES: &str = "chat:read chat:edit";
+const SCOPES: &str = "chat:read chat:edit user:read:follows";
 const DEVICE_URL: &str = "https://id.twitch.tv/oauth2/device";
 const TOKEN_URL: &str = "https://id.twitch.tv/oauth2/token";
 const VALIDATE_URL: &str = "https://id.twitch.tv/oauth2/validate";

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@ import { useLiveStatus } from "./composables/useLiveStatus";
 import { UNIFIED_CHAT_ID } from "./composables/useUnifiedChat";
 import "vue-sonner/style.css";
 import { Toaster } from "./components/ui/sonner";
+import FollowedChannelsSidebar from "./components/main/FollowedChannelsSidebar.vue";
 import SidebarPanel from "./components/main/SidebarPanel.vue";
 const StreamGrid = defineAsyncComponent(() => import("./components/main/StreamGrid.vue"));
 const EmptyState = defineAsyncComponent(() => import("./components/main/EmptyState.vue"));
@@ -218,6 +219,9 @@ onUnmounted(() => {
 
 <template>
   <div class="flex h-screen overflow-hidden bg-[#191b1f]">
+    <!-- left sidebar -->
+    <FollowedChannelsSidebar />
+
     <div class="flex flex-col flex-1 overflow-hidden relative">
       <div
         v-if="!isTauri() && !dismissedWebBanner"

--- a/src/components/chat/LoginPrompt.vue
+++ b/src/components/chat/LoginPrompt.vue
@@ -6,7 +6,9 @@ defineProps<{
   platform: "twitch" | "kick";
   loading?: boolean;
   position?: "top" | "bottom";
+  titleKey?: string;
   subtitleKey?: string;
+  compact?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -16,19 +18,32 @@ const emit = defineEmits<{
 
 <template>
   <div
-    class="p-3 bg-[#14161a] shrink-0 flex items-center justify-between gap-3"
-    :class="position === 'top' ? 'border-b border-[#2a2d33]' : 'border-t border-[#2a2d33]'"
+    class="bg-[#14161a] shrink-0 flex items-center justify-between"
+    :class="[
+      position === 'top' ? 'border-b border-[#2a2d33]' : 'border-t border-[#2a2d33]',
+      compact ? 'p-2 gap-2' : 'p-3 gap-3',
+    ]"
   >
-    <div class="flex items-center gap-2.5 overflow-hidden">
+    <div class="flex items-center overflow-hidden" :class="compact ? 'gap-1.5' : 'gap-2.5'">
       <div
-        class="w-8 h-8 rounded-lg bg-[#1e2127] border border-[#2a2d33] flex items-center justify-center shrink-0"
+        class="rounded-lg bg-[#1e2127] border border-[#2a2d33] flex items-center justify-center shrink-0"
+        :class="compact ? 'w-6 h-6' : 'w-8 h-8'"
       >
-        <TwitchIcon v-if="platform === 'twitch'" :size="16" :style="{ color: '#9146FF' }" />
-        <KickIcon v-else :size="16" :style="{ color: '#53fc18' }" />
+        <TwitchIcon
+          v-if="platform === 'twitch'"
+          :size="compact ? 12 : 16"
+          :style="{ color: '#9146FF' }"
+        />
+        <KickIcon v-else :size="compact ? 12 : 16" :style="{ color: '#53fc18' }" />
       </div>
       <div class="flex flex-col overflow-hidden leading-tight">
-        <span class="text-xs font-medium text-gray-200 truncate">{{ $t("chat.loginPrompt") }}</span>
-        <span class="text-[10px] text-gray-400 truncate mt-0.5">
+        <span
+          class="font-medium text-gray-200 truncate"
+          :class="compact ? 'text-[11px]' : 'text-xs'"
+        >
+          {{ titleKey ? $t(titleKey) : $t("chat.loginPrompt") }}
+        </span>
+        <span class="text-gray-400 truncate mt-0.5" :class="compact ? 'text-[9px]' : 'text-[10px]'">
           {{
             subtitleKey
               ? $t(subtitleKey)
@@ -42,8 +57,9 @@ const emit = defineEmits<{
     <Button
       variant="outline"
       size="sm"
-      class="h-8 px-3.5 text-xs font-medium transition-all shrink-0 border-[#2a2d33] bg-[#1e2127]"
+      class="font-medium transition-all shrink-0 border-[#2a2d33] bg-[#1e2127]"
       :class="[
+        compact ? 'h-6 px-2 text-[10px]' : 'h-8 px-3.5 text-xs',
         platform === 'twitch'
           ? 'text-[#bf94ff] hover:bg-[#9146FF]/10 hover:text-white hover:border-[#9146FF]/40'
           : 'text-[#53fc18] hover:bg-[#53fc18]/10 hover:text-white hover:border-[#53fc18]/40',

--- a/src/components/main/FollowedChannelsSidebar.vue
+++ b/src/components/main/FollowedChannelsSidebar.vue
@@ -1,0 +1,248 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { load } from "@tauri-apps/plugin-store";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../../components/ui/tooltip";
+import { Skeleton } from "../../components/ui/skeleton";
+import { Users, ChevronLeft, ChevronRight, RefreshCw } from "@lucide/vue";
+import TwitchIcon from "../../components/icons/TwitchIcon.vue";
+import KickIcon from "../../components/icons/KickIcon.vue";
+import LoginPrompt from "../../components/chat/LoginPrompt.vue";
+import { useI18n } from "vue-i18n";
+import { useFollowedChannels, type FollowedChannel } from "../../composables/useFollowedChannels";
+import { useTwitchAuth } from "../../composables/useTwitchAuth";
+import { useStreams } from "../../composables/useStreams";
+import { isTauri } from "../../composables/useUpdater";
+const { channels, isLoading, platformFilter, refresh } = useFollowedChannels();
+const { addStream } = useStreams();
+const { t } = useI18n();
+const { authenticated: isTwitchAuth } = useTwitchAuth();
+
+const openTwitchAuthDialog = () => {
+  window.dispatchEvent(new CustomEvent("multistream-show-dialog", { detail: "twitch-auth" }));
+};
+
+const isOpen = ref(false);
+let store: any = null;
+
+const initStore = async () => {
+  if (!isTauri()) return;
+  try {
+    store = await load("sidebar.json", { autoSave: true } as any);
+    const stored = await store.get("left-sidebar-open");
+    if (stored !== null) {
+      isOpen.value = stored as boolean;
+    }
+  } catch (e) {
+    console.error("Failed to load store", e);
+  }
+};
+
+const toggleSidebar = async () => {
+  isOpen.value = !isOpen.value;
+  if (store) {
+    await store.set("left-sidebar-open", isOpen.value);
+  }
+  if (isOpen.value) {
+    refresh();
+  }
+};
+
+onMounted(() => {
+  initStore();
+});
+
+const onAddClick = (channel: FollowedChannel) => {
+  addStream(channel.id, channel.platform);
+};
+
+const formatViewers = (count: number) => {
+  if (count >= 1000) {
+    return (count / 1000).toFixed(1) + "k";
+  }
+  return count.toString();
+};
+
+const togglePlatform = () => {
+  if (platformFilter.value === "all") platformFilter.value = "twitch";
+  else if (platformFilter.value === "twitch") platformFilter.value = "kick";
+  else platformFilter.value = "all";
+};
+</script>
+
+<template>
+  <div
+    class="flex-shrink-0 transition-all duration-300 ease-in-out border-r border-[#2a2d33] bg-[#14161a] h-full flex flex-col z-20 relative"
+    :class="isOpen ? 'w-56' : 'w-14'"
+  >
+    <div
+      class="h-12 flex items-center px-2 border-b border-[#2a2d33] shrink-0"
+      :class="isOpen ? 'justify-between' : 'justify-center'"
+    >
+      <div v-if="isOpen" class="flex items-center gap-2 text-white font-medium">
+        <Users class="w-4 h-4 text-gray-400" />
+        <span class="text-sm">{{ t("sidebar.followedChannels") }}</span>
+      </div>
+
+      <button
+        class="p-1.5 rounded-md text-gray-400 hover:text-white hover:bg-[#1f2227] transition-colors"
+        @click="toggleSidebar"
+      >
+        <ChevronLeft v-if="isOpen" class="w-4 h-4" />
+        <ChevronRight v-else class="w-4 h-4" />
+      </button>
+    </div>
+
+    <div
+      v-if="isOpen"
+      class="px-2 py-1.5 border-b border-[#2a2d33] flex items-center justify-between"
+    >
+      <button
+        class="text-xs font-medium text-gray-400 hover:text-white uppercase transition-colors"
+        @click="togglePlatform"
+      >
+        {{ platformFilter === "all" ? t("sidebar.all") : platformFilter }}
+      </button>
+      <button
+        class="text-gray-500 hover:text-gray-300 transition-colors p-1 -mr-1 rounded-md"
+        :class="{ 'pointer-events-none': isLoading }"
+        @click="refresh"
+      >
+        <RefreshCw class="w-3.5 h-3.5" :class="{ 'animate-spin text-gray-400': isLoading }" />
+      </button>
+    </div>
+
+    <TooltipProvider :delay-duration="0">
+      <div class="flex-1 overflow-y-auto py-1 flex flex-col gap-0.5 px-1.5 custom-scrollbar">
+        <template v-if="isLoading && channels.filter((c) => c.isLive).length === 0">
+          <div v-for="i in 10" :key="i" class="flex items-center gap-2 p-1 rounded-md">
+            <div class="relative shrink-0">
+              <Skeleton class="w-7 h-7 rounded-full border border-[#2a2d33] bg-[#1f2227]" />
+              <div
+                class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full border border-[#14161a] flex items-center justify-center bg-[#0f1115]"
+              >
+                <Skeleton class="w-2.5 h-2.5 rounded-full bg-[#2a2d33]" />
+              </div>
+            </div>
+
+            <div v-if="isOpen" class="flex-1 min-w-0 flex flex-col justify-center">
+              <div class="flex items-center justify-between gap-2">
+                <Skeleton class="h-3.5 w-20 bg-[#1f2227]" />
+                <div class="flex items-center gap-1 shrink-0">
+                  <Skeleton class="w-1.5 h-1.5 rounded-full bg-[#1f2227]" />
+                  <Skeleton class="h-3 w-5 bg-[#1f2227]" />
+                </div>
+              </div>
+              <Skeleton class="h-3 w-28 bg-[#1f2227] mt-1" />
+            </div>
+          </div>
+        </template>
+
+        <template
+          v-for="channel in channels.filter((c) => c.isLive)"
+          v-else
+          :key="channel.platform + '-' + channel.id"
+        >
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <div
+                class="flex items-center gap-2 p-1 rounded-md hover:bg-[#1f2227] cursor-pointer group transition-colors"
+                @click.stop="onAddClick(channel)"
+              >
+                <div class="relative shrink-0">
+                  <img
+                    :src="
+                      channel.avatarUrl ||
+                      `https://ui-avatars.com/api/?name=${channel.displayName}&background=random`
+                    "
+                    class="w-7 h-7 rounded-full border border-[#2a2d33] object-cover"
+                  />
+                  <div
+                    class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full border border-[#14161a] flex items-center justify-center bg-[#0f1115]"
+                  >
+                    <TwitchIcon
+                      v-if="channel.platform === 'twitch'"
+                      class="w-2.5 h-2.5 text-[#9146FF]"
+                    />
+                    <KickIcon
+                      v-if="channel.platform === 'kick'"
+                      class="w-2.5 h-2.5 text-[#53FC18]"
+                    />
+                  </div>
+                </div>
+
+                <div v-if="isOpen" class="flex-1 min-w-0 flex flex-col justify-center">
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-sm font-medium text-gray-200 truncate">{{
+                      channel.displayName
+                    }}</span>
+                    <div class="flex items-center gap-1 text-rose-400 shrink-0">
+                      <div class="w-1.5 h-1.5 rounded-full bg-rose-500 animate-pulse"></div>
+                      <span class="text-xs font-semibold">{{
+                        formatViewers(channel.viewerCount || 0)
+                      }}</span>
+                    </div>
+                  </div>
+                  <span
+                    v-if="channel.game || channel.title"
+                    class="text-xs text-gray-400 truncate"
+                    >{{ channel.game || channel.title }}</span
+                  >
+                </div>
+              </div>
+            </TooltipTrigger>
+
+            <TooltipContent
+              side="right"
+              :side-offset="10"
+              class="w-64 p-0 bg-[#0f1115] border-[#2a2d33] rounded-lg shadow-xl shadow-black/50 overflow-hidden"
+              hide-arrow
+            >
+              <img
+                v-if="channel.thumbnailUrl"
+                :src="channel.thumbnailUrl"
+                referrerpolicy="no-referrer"
+                class="w-full aspect-video object-cover"
+              />
+              <div v-else class="w-full aspect-video bg-[#14161a] border-b border-[#2a2d33]"></div>
+              <div class="p-2">
+                <h4 class="text-sm font-medium text-white line-clamp-1">{{ channel.title }}</h4>
+                <p class="text-xs text-gray-400 mt-0.5 truncate">{{ channel.game }}</p>
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        </template>
+      </div>
+    </TooltipProvider>
+
+    <LoginPrompt
+      v-if="isOpen && !isTwitchAuth"
+      platform="twitch"
+      position="top"
+      title-key="sidebar.loginTitle"
+      subtitle-key="sidebar.loginSubtitle"
+      compact
+      @connect="openTwitchAuthDialog"
+    />
+  </div>
+</template>
+
+<style scoped>
+.custom-scrollbar::-webkit-scrollbar {
+  width: 4px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #2a2d33;
+  border-radius: 4px;
+}
+.custom-scrollbar:hover::-webkit-scrollbar-thumb {
+  background: #3a3f4b;
+}
+</style>

--- a/src/components/main/FollowedChannelsSidebar.vue
+++ b/src/components/main/FollowedChannelsSidebar.vue
@@ -157,7 +157,7 @@ const togglePlatform = () => {
                   <img
                     :src="
                       channel.avatarUrl ||
-                      `https://ui-avatars.com/api/?name=${channel.displayName}&background=random`
+                      `https://ui-avatars.com/api/?name=${encodeURIComponent(channel.displayName)}&background=random`
                     "
                     class="w-7 h-7 rounded-full border border-[#2a2d33] object-cover"
                   />

--- a/src/components/main/SidebarPanel.vue
+++ b/src/components/main/SidebarPanel.vue
@@ -153,7 +153,7 @@ onUnmounted(() => {
 
 <template>
   <aside
-    class="shadow-lg transition-all duration-200 flex flex-col overflow-hidden"
+    class="shadow-lg transition-all duration-200 flex flex-col overflow-hidden border-l border-[#2a2d33]"
     :class="sidebarOpen ? 'w-80' : 'w-0'"
   >
     <div

--- a/src/composables/__tests__/useFollowedChannels.spec.ts
+++ b/src/composables/__tests__/useFollowedChannels.spec.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useFollowedChannels } from "../useFollowedChannels";
+import type { FavoriteChannel } from "../useFavorites";
+import { ref } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+
+// Mock Tauri invoke
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+// Mock @vueuse/core to bypass createSharedComposable singleton behavior for tests
+vi.mock("@vueuse/core", () => ({
+  createSharedComposable: (fn: any) => fn,
+}));
+
+// Mock useUpdater (isTauri)
+const mockIsTauri = vi.fn(() => true);
+vi.mock("../useUpdater", () => ({
+  isTauri: () => mockIsTauri(),
+}));
+
+// Mock composables dependencies
+const mockTwitchAuth = { authenticated: ref(false) };
+vi.mock("../useTwitchAuth", () => ({
+  useTwitchAuth: () => mockTwitchAuth,
+}));
+
+const mockKickAuth = { authenticated: ref(false) };
+vi.mock("../useKickAuth", () => ({
+  useKickAuth: () => mockKickAuth,
+}));
+
+const mockLiveStatus = { statuses: ref({}) };
+vi.mock("../useLiveStatus", () => ({
+  useLiveStatus: () => mockLiveStatus,
+}));
+
+const mockFavorites = { favorites: ref<FavoriteChannel[]>([]) };
+vi.mock("../useFavorites", () => ({
+  useFavorites: () => mockFavorites,
+}));
+
+describe("useFollowedChannels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTauri.mockReturnValue(true);
+    mockTwitchAuth.authenticated.value = false;
+    mockKickAuth.authenticated.value = false;
+    mockLiveStatus.statuses.value = {};
+    mockFavorites.favorites.value = [];
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return empty channels initially if not authenticated", () => {
+    // Arrange
+    mockTwitchAuth.authenticated.value = false;
+    mockKickAuth.authenticated.value = false;
+
+    // Act
+    const { channels } = useFollowedChannels();
+
+    // Assert
+    expect(channels.value).toEqual([]);
+  });
+
+  it("should not fetch twitch channels if twitch is not authenticated", async () => {
+    // Arrange
+    mockTwitchAuth.authenticated.value = false;
+
+    // Act
+    const { refresh } = useFollowedChannels();
+    await refresh();
+
+    // Assert
+    expect(invoke).not.toHaveBeenCalledWith("twitch_get_followed_streams");
+  });
+
+  it("should fetch twitch channels if twitch is authenticated", async () => {
+    // Arrange
+    mockTwitchAuth.authenticated.value = true;
+    const mockTwitchData = [
+      { id: "123", platform: "twitch", displayName: "TestTwitch", isLive: true, viewerCount: 100 },
+    ];
+    vi.mocked(invoke).mockResolvedValueOnce(mockTwitchData);
+
+    // Act
+    const { refresh, channels } = useFollowedChannels();
+    await refresh();
+
+    // Assert
+    expect(invoke).toHaveBeenCalledWith("twitch_get_followed_streams");
+    expect(channels.value).toEqual(mockTwitchData);
+  });
+
+  it("should populate kick channels from favorites and statuses when kick is authenticated", () => {
+    // Arrange
+    mockKickAuth.authenticated.value = true;
+    mockFavorites.favorites.value = [{ channel: "testkick", platform: "kick", addedAt: 0 }];
+    mockLiveStatus.statuses.value = {
+      "kick:testkick": {
+        isLive: true,
+        viewerCount: 50,
+        title: "Test Kick Stream",
+        category: "Just Chatting",
+        avatarUrl: "http://avatar.com/kick",
+        thumbnailUrl: "http://thumb.com/kick",
+      } as any,
+    };
+
+    // Act
+    const { channels } = useFollowedChannels();
+
+    // Assert
+    expect(channels.value).toHaveLength(1);
+    expect(channels.value[0]).toEqual({
+      id: "testkick",
+      platform: "kick",
+      displayName: "testkick",
+      avatarUrl: "http://avatar.com/kick",
+      isLive: true,
+      viewerCount: 50,
+      title: "Test Kick Stream",
+      game: "Just Chatting",
+      thumbnailUrl: "http://thumb.com/kick",
+    });
+  });
+
+  it("should combine and sort channels correctly", async () => {
+    // Arrange
+    mockTwitchAuth.authenticated.value = true;
+    mockKickAuth.authenticated.value = true;
+
+    const mockTwitchData = [
+      { id: "1", platform: "twitch", displayName: "A_Twitch", isLive: true, viewerCount: 10 },
+      { id: "2", platform: "twitch", displayName: "B_Twitch", isLive: false, viewerCount: 0 },
+    ];
+    vi.mocked(invoke).mockResolvedValueOnce(mockTwitchData);
+
+    mockFavorites.favorites.value = [{ channel: "C_Kick", platform: "kick", addedAt: 0 }];
+    mockLiveStatus.statuses.value = {
+      "kick:c_kick": { isLive: true, viewerCount: 50 } as any,
+    };
+
+    const { refresh, channels } = useFollowedChannels();
+    await refresh();
+
+    // Act (Sorting rules: viewerCount desc, then isLive, then displayName)
+    // C_Kick (50 viewers) should be first
+    // A_Twitch (10 viewers) should be second
+    // B_Twitch (0 viewers, offline) should be last
+
+    // Assert
+    expect(channels.value).toHaveLength(3);
+    expect(channels.value[0]?.displayName).toBe("C_Kick");
+    expect(channels.value[1]?.displayName).toBe("A_Twitch");
+    expect(channels.value[2]?.displayName).toBe("B_Twitch");
+  });
+
+  it("should filter channels by platform correctly", async () => {
+    // Arrange
+    mockTwitchAuth.authenticated.value = true;
+    mockKickAuth.authenticated.value = true;
+
+    vi.mocked(invoke).mockResolvedValueOnce([
+      { id: "1", platform: "twitch", displayName: "A", isLive: true, viewerCount: 10 },
+    ]);
+    mockFavorites.favorites.value = [{ channel: "B", platform: "kick", addedAt: 0 }];
+    mockLiveStatus.statuses.value = {
+      "kick:b": { isLive: true, viewerCount: 50 } as any,
+    };
+
+    const { refresh, channels, platformFilter } = useFollowedChannels();
+    await refresh();
+
+    // Act & Assert
+    expect(channels.value).toHaveLength(2);
+
+    platformFilter.value = "twitch";
+    expect(channels.value).toHaveLength(1);
+    expect(channels.value[0]?.platform).toBe("twitch");
+
+    platformFilter.value = "kick";
+    expect(channels.value).toHaveLength(1);
+    expect(channels.value[0]?.platform).toBe("kick");
+  });
+
+  it("should handle twitch fetch errors gracefully", async () => {
+    // Arrange
+    mockTwitchAuth.authenticated.value = true;
+    vi.mocked(invoke).mockRejectedValueOnce(new Error("Network Error"));
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Act
+    const { refresh, channels } = useFollowedChannels();
+    await refresh();
+
+    // Assert
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(channels.value).toEqual([]);
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/composables/__tests__/useLiveStatus.spec.ts
+++ b/src/composables/__tests__/useLiveStatus.spec.ts
@@ -233,6 +233,7 @@ describe("useLiveStatus composable unit tests (Critical Paths)", () => {
         title: "TRIBOMINERA",
         viewerCount: 50000,
         category: "CS:GO",
+        thumbnailUrl: "https://static-cdn.jtvnw.net/previews-ttv/live_user_gaules-320x180.jpg",
       });
 
       expect(sut.statuses.value["kick:alanzoka"]).toEqual({

--- a/src/composables/useFollowedChannels.ts
+++ b/src/composables/useFollowedChannels.ts
@@ -37,20 +37,22 @@ const _useFollowedChannels = () => {
     if (!kickAuthenticated.value) return [];
 
     const kickFavs = favorites.value.filter((f) => f.platform === "kick");
-    return kickFavs.map((f) => {
-      const status = statuses.value[`kick:${f.channel.toLowerCase()}`];
-      return {
-        id: f.channel,
-        platform: "kick",
-        displayName: f.channel,
-        avatarUrl: status?.avatarUrl ?? "",
-        isLive: status?.isLive ?? false,
-        viewerCount: status?.viewerCount ?? 0,
-        title: status?.title,
-        game: status?.category,
-        thumbnailUrl: status?.thumbnailUrl,
-      };
-    });
+    return kickFavs
+      .map((f) => {
+        const status = statuses.value[`kick:${f.channel.toLowerCase()}`];
+        return {
+          id: f.channel,
+          platform: "kick" as const,
+          displayName: f.channel,
+          avatarUrl: status?.avatarUrl ?? "",
+          isLive: status?.isLive ?? false,
+          viewerCount: status?.viewerCount ?? 0,
+          title: status?.title,
+          game: status?.category,
+          thumbnailUrl: status?.thumbnailUrl,
+        };
+      })
+      .filter((channel) => channel.isLive);
   });
 
   const channels = computed<FollowedChannel[]>(() => {

--- a/src/composables/useFollowedChannels.ts
+++ b/src/composables/useFollowedChannels.ts
@@ -1,0 +1,149 @@
+import { ref, computed, onScopeDispose, watch } from "vue";
+import { createSharedComposable } from "@vueuse/core";
+import { invoke } from "@tauri-apps/api/core";
+
+export const debugErrors = ref<string[]>([]);
+import { isTauri } from "./useUpdater";
+import { useTwitchAuth } from "./useTwitchAuth";
+import { useKickAuth } from "./useKickAuth";
+import { useLiveStatus } from "./useLiveStatus";
+import { useFavorites } from "./useFavorites";
+import { REFRESH_CONFIG } from "@/config/api";
+
+export interface FollowedChannel {
+  id: string;
+  platform: "twitch" | "kick";
+  displayName: string;
+  avatarUrl: string;
+  isLive: boolean;
+  viewerCount?: number;
+  game?: string;
+  thumbnailUrl?: string;
+  title?: string;
+}
+
+const _useFollowedChannels = () => {
+  const twitchChannels = ref<FollowedChannel[]>([]);
+  const isLoading = ref(false);
+  const platformFilter = ref<"all" | "twitch" | "kick">("all");
+
+  const { authenticated: twitchAuthenticated } = useTwitchAuth();
+  const { authenticated: kickAuthenticated } = useKickAuth();
+  const { statuses } = useLiveStatus();
+  const { favorites } = useFavorites();
+  let pollInterval: ReturnType<typeof setInterval> | null = null;
+
+  const kickChannels = computed<FollowedChannel[]>(() => {
+    if (!kickAuthenticated.value) return [];
+
+    const kickFavs = favorites.value.filter((f) => f.platform === "kick");
+    return kickFavs.map((f) => {
+      const status = statuses.value[`kick:${f.channel.toLowerCase()}`];
+      return {
+        id: f.channel,
+        platform: "kick",
+        displayName: f.channel,
+        avatarUrl: status?.avatarUrl ?? "",
+        isLive: status?.isLive ?? false,
+        viewerCount: status?.viewerCount ?? 0,
+        title: status?.title,
+        game: status?.category,
+        thumbnailUrl: status?.thumbnailUrl,
+      };
+    });
+  });
+
+  const channels = computed<FollowedChannel[]>(() => {
+    const combined = [...twitchChannels.value, ...kickChannels.value];
+
+    combined.sort((a, b) => {
+      const viewersA = a.viewerCount || 0;
+      const viewersB = b.viewerCount || 0;
+      if (viewersA !== viewersB) return viewersB - viewersA;
+      if (a.isLive !== b.isLive) return a.isLive ? -1 : 1;
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+    return combined;
+  });
+
+  const filteredChannels = computed(() => {
+    if (platformFilter.value === "all") return channels.value;
+    return channels.value.filter((c) => c.platform === platformFilter.value);
+  });
+
+  const refresh = async () => {
+    if (!isTauri() || isLoading.value) return;
+
+    isLoading.value = true;
+    debugErrors.value = [];
+    try {
+      if (twitchAuthenticated.value) {
+        const results = await invoke<FollowedChannel[]>("twitch_get_followed_streams").catch(
+          (e) => {
+            console.error("Failed to fetch Twitch followed streams", e);
+            debugErrors.value.push(`Twitch: ${String(e)}`);
+            return [];
+          }
+        );
+        twitchChannels.value = results;
+      } else {
+        twitchChannels.value = [];
+      }
+    } catch (e) {
+      console.error("Failed to refresh followed channels", e);
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  const startPolling = () => {
+    if (pollInterval) clearInterval(pollInterval);
+    refresh();
+    pollInterval = setInterval(refresh, REFRESH_CONFIG.interval);
+  };
+
+  const stopPolling = () => {
+    if (pollInterval) {
+      clearInterval(pollInterval);
+      pollInterval = null;
+    }
+  };
+
+  watch([twitchAuthenticated, kickAuthenticated], () => {
+    if (typeof document !== "undefined" && document.visibilityState === "visible") {
+      refresh();
+    }
+  });
+
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      startPolling();
+    } else {
+      stopPolling();
+    }
+  };
+
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    // Initial fetch
+    if (document.visibilityState === "visible") {
+      startPolling();
+    }
+
+    onScopeDispose(() => {
+      stopPolling();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    });
+  }
+
+  return {
+    channels: filteredChannels,
+    isLoading,
+    platformFilter,
+    refresh,
+  };
+};
+
+export const useFollowedChannels = createSharedComposable(_useFollowedChannels);

--- a/src/composables/useLiveStatus.ts
+++ b/src/composables/useLiveStatus.ts
@@ -16,6 +16,8 @@ export interface LiveStatus {
   viewerCount?: number;
   title?: string;
   category?: string;
+  avatarUrl?: string;
+  thumbnailUrl?: string;
 }
 
 export interface SuggestedStream {
@@ -94,6 +96,7 @@ async function checkTwitchStreams(channels: string[]): Promise<StatusMap | null>
           viewerCount: userData.stream.viewersCount,
           title: userData.stream.title,
           category: userData.stream.game?.displayName,
+          thumbnailUrl: `https://static-cdn.jtvnw.net/previews-ttv/live_user_${ch.toLowerCase()}-320x180.jpg`,
         };
       }
     });
@@ -237,9 +240,14 @@ async function checkKickStreams(channels: string[]): Promise<StatusMap | null> {
           viewerCount: data.livestream.viewer_count,
           title: data.livestream.session_title,
           category: data.livestream.categories?.[0]?.name,
+          avatarUrl: data.user?.profile_pic,
+          thumbnailUrl: data.livestream.thumbnail?.url || data.livestream.thumbnail?.src,
         };
       } else {
-        result[key] = { isLive: false };
+        result[key] = {
+          isLive: false,
+          avatarUrl: data?.user?.profile_pic,
+        };
       }
     } catch {
       failedCount++;

--- a/src/i18n/locales/cn.json
+++ b/src/i18n/locales/cn.json
@@ -299,5 +299,11 @@
   "webBanner": {
     "title": "Multistream 在桌面应用上运行得更好。",
     "button": "下载"
+  },
+  "sidebar": {
+    "followedChannels": "已关注频道",
+    "all": "全部",
+    "loginTitle": "连接您的账户",
+    "loginSubtitle": "查看您关注的频道"
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -299,5 +299,11 @@
   "webBanner": {
     "title": "Multistream läuft besser als Desktop-App.",
     "button": "Herunterladen"
+  },
+  "sidebar": {
+    "followedChannels": "Gefolgte Kanäle",
+    "all": "Alle",
+    "loginTitle": "Konto verbinden",
+    "loginSubtitle": "Sehen Sie die Kanäle, denen Sie folgen"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -299,5 +299,11 @@
   "webBanner": {
     "title": "Multistream runs better on the desktop app.",
     "button": "Download"
+  },
+  "sidebar": {
+    "followedChannels": "Followed Channels",
+    "all": "All",
+    "loginTitle": "Connect your account",
+    "loginSubtitle": "See the channels you follow"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -299,5 +299,11 @@
   "webBanner": {
     "title": "Multistream funciona mejor en la app de escritorio.",
     "button": "Descargar"
+  },
+  "sidebar": {
+    "followedChannels": "Canales seguidos",
+    "all": "Todos",
+    "loginTitle": "Conecta tu cuenta",
+    "loginSubtitle": "Mira los canales que sigues"
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -299,5 +299,11 @@
   "webBanner": {
     "title": "O Multistream roda melhor no app desktop.",
     "button": "Baixar"
+  },
+  "sidebar": {
+    "followedChannels": "Canais seguidos",
+    "all": "Todos",
+    "loginTitle": "Conecte sua conta",
+    "loginSubtitle": "Veja os canais que você segue"
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -299,5 +299,11 @@
   "webBanner": {
     "title": "Multistream работает лучше в десктопном приложении.",
     "button": "Скачать"
+  },
+  "sidebar": {
+    "followedChannels": "Отслеживаемые каналы",
+    "all": "Все",
+    "loginTitle": "Подключите аккаунт",
+    "loginSubtitle": "Смотрите каналы, на которые вы подписаны"
   }
 }


### PR DESCRIPTION
**Description**: Adds a new left sidebar to display the user's followed channels that are currently live. It merges data from both Twitch and Kick into a unified, sortable list.

**Key Changes**:
- Added Rust backend commands (`twitch_get_followed_streams`) to fetch live followed channels from Twitch.
- Created `useFollowedChannels` composable to manage state, platform merging, and data fetching. 
- Added `FollowedChannelsSidebar` component and integrated it into the main layout.              
- Refactored `LoginPrompt.vue` with a new `compact` prop to display an inline login warning when the user is unauthenticated.                                                                       
- Added unit tests for the new composable with full coverage.                                    
- Updated i18n JSON files for all 6 supported locales.

**Notes**: 
- Kick channels are aggregated using the local `favorites` and `liveStatus` mechanism, as Kick lacks a public API endpoint for followed channels.                                                 
- Offline streams are intentionally filtered out to preserve screen space and keep the UI clean. 
- The list is automatically sorted by viewer count in descending order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new sidebar for followed live channels, with platform filtering, refresh, and expand/collapse support.
  * Users can now quickly open a followed channel’s stream from the sidebar.
  * Added support for showing channel avatars, thumbnails, viewer counts, and live details.

* **Bug Fixes**
  * Improved account handling for followed-stream access when login expires.
  * Updated login prompt layout to better support compact display and localized text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->