### PR TITLE
fix: bundle GStreamer plugins in AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,8 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev \
+            gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-libav
 
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile

--- a/apps/desktop/src-tauri/tauri.linux.conf.json
+++ b/apps/desktop/src-tauri/tauri.linux.conf.json
@@ -1,5 +1,10 @@
 {
   "bundle": {
-    "createUpdaterArtifacts": "v1Compatible"
+    "createUpdaterArtifacts": "v1Compatible",
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": true
+      }
+    }
   }
 }


### PR DESCRIPTION
The AppImage provides WebKit's GStreamer core libraries but no GStreamer plugins,
plugins are loaded at runtime via GStreamer's registry rather than linked as ELF
dependencies, so the AppImage bundler's dependency scanner never picks them up.
The generated launcher also sets `GST_PLUGIN_SYSTEM_PATH_1_0` to a directory inside
the bundle that doesn't exist, and setting that variable replaces GStreamer's
default search path instead of extending it, so plugins installed on the host
system are never found either, regardless of distro.

As a result, WebKit can't create `autoaudiosink` and WebKitWebProcess crashes
shortly after launch (tested on Fedora 44):

> GStreamer element autoaudiosink not found. Please install it
>
> (WebKitWebProcess:57537): GLib-GObject-WARNING **: invalid (NULL) pointer instance
>
> (WebKitWebProcess:57537): GLib-GObject-CRITICAL **: g_signal_connect_data: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed

This is a known Tauri issue (tauri-apps/tauri#4092), I fixed it the way Tauri documents it:

- Enable `bundle.linux.appimage.bundleMediaFramework` so the build machine's
  GStreamer plugins get bundled into the AppImage with an AppRun hook pointing at them.
- Install the GStreamer plugin packages on the CI runner so there are plugins to bundle.

Tested by rebuilding the AppImage in an ubuntu-22.04 container matching CI:
bundle now contains the GStreamer plugin set, crash no longer occurs, and media playback
works (tested on Fedora 44).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media playback support in Linux AppImage releases.
  * Added required media framework components to Ubuntu release builds for more reliable audio and video functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->