### PR TITLE
ci: configure homebrew release for macOS users

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,34 +252,6 @@ jobs:
           echo "=== Release files ==="
           ls -la release-files/
 
-      - name: Checkout Homebrew tap
-        uses: actions/checkout@v4
-        with:
-          repository: ilanzgx/homebrew-multistream
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-tap
-
-      - name: Update Homebrew Cask
-        working-directory: release-files
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          SHA_ARM=$(shasum -a 256 Multistream-macos-arm64.dmg | awk '{print $1}')
-          SHA_X64=$(shasum -a 256 Multistream-macos-x64.dmg  | awk '{print $1}')
-          VERSION="${TAG#v}"
-
-          CASK="../homebrew-tap/Casks/multistream.rb"
-          sed -i "s/version \"[^\"]*\"/version \"${VERSION}\"/" "$CASK"
-          sed -i "/on_arm/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${SHA_ARM}\"/}" "$CASK"
-          sed -i "/on_intel/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${SHA_X64}\"/}" "$CASK"
-
-          cd ../homebrew-tap
-          git config user.name  "multistream-bot"
-          git config user.email "bot@multistream.app"
-          git add Casks/multistream.rb
-          git commit -m "chore: update cask to ${VERSION}"
-          git push
-
       - name: Build updater manifest
         working-directory: release-files
         env:
@@ -341,3 +313,35 @@ jobs:
           name: Multistream ${{ github.ref_name }}
           body_path: changelog.md
           files: release-files/*
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: ilanzgx/homebrew-multistream
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Homebrew Cask
+        working-directory: release-files
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          SHA_ARM=$(shasum -a 256 Multistream-macos-arm64.dmg | awk '{print $1}')
+          SHA_X64=$(shasum -a 256 Multistream-macos-x64.dmg  | awk '{print $1}')
+          VERSION="${TAG#v}"
+
+          CASK="../homebrew-tap/Casks/multistream.rb"
+          sed -i "s/version \"[^\"]*\"/version \"${VERSION}\"/" "$CASK"
+          sed -i "/on_arm/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${SHA_ARM}\"/}" "$CASK"
+          sed -i "/on_intel/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${SHA_X64}\"/}" "$CASK"
+
+          cd ../homebrew-tap
+          git config user.name "multistream-bot"
+          git config user.email "bot@multistream.app"
+          git add Casks/multistream.rb
+          
+          # Only commit and push if there are changes
+          git diff --quiet --staged || {
+            git commit -m "chore(homebrew): update cask to ${VERSION}"
+            git push
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,34 @@ jobs:
           echo "=== Release files ==="
           ls -la release-files/
 
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: ilanzgx/homebrew-multistream
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Homebrew Cask
+        working-directory: release-files
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          SHA_ARM=$(shasum -a 256 Multistream-macos-arm64.dmg | awk '{print $1}')
+          SHA_X64=$(shasum -a 256 Multistream-macos-x64.dmg  | awk '{print $1}')
+          VERSION="${TAG#v}"
+
+          CASK="../homebrew-tap/Casks/multistream.rb"
+          sed -i "s/version \"[^\"]*\"/version \"${VERSION}\"/" "$CASK"
+          sed -i "/on_arm/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${SHA_ARM}\"/}" "$CASK"
+          sed -i "/on_intel/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${SHA_X64}\"/}" "$CASK"
+
+          cd ../homebrew-tap
+          git config user.name  "multistream-bot"
+          git config user.email "bot@multistream.app"
+          git add Casks/multistream.rb
+          git commit -m "chore: update cask to ${VERSION}"
+          git push
+
       - name: Build updater manifest
         working-directory: release-files
         env:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ Most multistream setups are just browser tabs. Multistream is a desktop app buil
 - [Tauri 2](https://v2.tauri.app/)
 - [Tailwind CSS](https://tailwindcss.com/)
 
+## Important for macOS Users
+
+As a free, open-source project, Multistream is distributed without a paid Apple Developer certificate. This causes macOS Gatekeeper to flag the application as "damaged" by default.
+
+If you see the error _"Multistream is damaged and can't be opened"_, you have two options:
+
+**1. Install via Homebrew (Recommended):**
+
+```sh
+brew install --cask ilanzgx/multistream/multistream
+```
+
+**2. Fix manually after downloading the DMG:**
+
+```sh
+xattr -cr /Applications/Multistream.app
+```
+
 ## Getting started
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ brew install --cask ilanzgx/multistream/multistream
 
 **2. Fix manually after downloading the DMG:**
 
+Move `Multistream.app` to your `/Applications` folder, then run:
 ```sh
-xattr -cr /Applications/Multistream.app
+xattr -dr com.apple.quarantine /Applications/Multistream.app
 ```
 
 ## Getting started


### PR DESCRIPTION
**Description**: This PR automates updating our Homebrew Cask during the release pipeline. macOS users keep hitting the Gatekeeper "damaged app" error because we aren't notarized. Distributing via Homebrew bypasses this quarantine automatically without forcing users to run `xattr` manually.

**Key Changes**:
- Adds a step in `release.yml` to clone the `ilanzgx/homebrew-multistream` tap.
- Grabs the SHA-256 hashes from the newly built macOS DMGs.
- Bumps the version and hashes in the `multistream.rb` Cask file using sed.
- Pushes the update back to the tap repo as `multistream-bot`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added macOS troubleshooting guidance for Gatekeeper’s “damaged” app warning.
  * Added Homebrew installation instructions and manual remediation steps.

* **Release Improvements**
  * Automated Homebrew cask updates with new release versions and architecture-specific checksums for macOS downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->