### PR TITLE
fix(chat): correct emote insertion position and prevent text erasure

### DIFF
--- a/apps/desktop/e2e/sidebar-favorites.spec.ts
+++ b/apps/desktop/e2e/sidebar-favorites.spec.ts
@@ -20,18 +20,19 @@ test.describe("Favorites & Recents E2E Test", () => {
   test("favorites appear in AddDialog and can be quick-added to grid", async ({ page }) => {
     // Act: open AddDialog
     await page.getByTestId("add-stream-btn").click();
-    await expect(page.getByRole("dialog")).toBeVisible();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
 
-    // Assert: favorites section is visible with "shroud"
-    await expect(page.getByText("Favorites")).toBeVisible();
-    const favoriteChip = page.getByText("shroud");
+    // Assert: favorites section is visible with "shroud" inside dialog
+    await expect(dialog.getByText("Favorites")).toBeVisible();
+    const favoriteChip = dialog.getByTestId("stream-chip-shroud");
     await expect(favoriteChip).toBeVisible();
 
     // Act: click favorite chip to quick-add
     await favoriteChip.click();
 
     // Assert: dialog closes and stream appears in grid
-    await expect(page.getByRole("dialog")).not.toBeVisible();
+    await expect(dialog).not.toBeVisible();
     await expect(page.getByTestId("stream-item-shroud")).toBeVisible();
   });
 });

--- a/apps/desktop/src/components/chat/ChatRichInput.vue
+++ b/apps/desktop/src/components/chat/ChatRichInput.vue
@@ -39,7 +39,7 @@ function extractPlainText(node: Node): string {
       }
     }
   }
-  return text.replace(/\r?\n+/g, " ").trim();
+  return text.replace(/\r?\n+/g, " ");
 }
 
 function getSelectionOffsetsWithin(element: HTMLElement) {
@@ -229,7 +229,7 @@ function handleSelectionChange() {
   if (!sel || sel.rangeCount === 0) return;
 
   const isInside =
-    editorRef.value.contains(sel.anchorNode) || editorRef.value.contains(sel.focusNode);
+    editorRef.value.contains(sel.anchorNode) && editorRef.value.contains(sel.focusNode);
 
   if (!isInside) {
     const highlighted = editorRef.value.querySelectorAll("img.bg-blue-500\\/40");

--- a/apps/desktop/src/components/chat/ChatRichInput.vue
+++ b/apps/desktop/src/components/chat/ChatRichInput.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onUnmounted, watch } from "vue";
 import EmotePicker from "./EmotePicker.vue";
 import type { PickerEmote } from "@/composables/useRecentEmotes";
 import { type EmoteData } from "@/composables/useEmotes";
+import { calculateEmoteInsertion, generateHtmlFromText } from "@/lib/chatInput";
 
 const props = defineProps<{
   modelValue: string;
@@ -18,6 +19,7 @@ const emit = defineEmits<{
 
 const editorRef = ref<HTMLElement | null>(null);
 const selectionOffsets = ref({ start: 0, end: 0 });
+const hasUserInteracted = ref(false);
 
 function extractPlainText(node: Node): string {
   let text = "";
@@ -37,7 +39,7 @@ function extractPlainText(node: Node): string {
       }
     }
   }
-  return text.replace(/\n/g, ""); // Twitch chat doesn't support multiline, and stripping newlines fixes the trailing <br> issue
+  return text.replace(/\r?\n+/g, " ").trim();
 }
 
 function getSelectionOffsetsWithin(element: HTMLElement) {
@@ -46,6 +48,10 @@ function getSelectionOffsetsWithin(element: HTMLElement) {
   const selection = window.getSelection();
   if (selection && selection.rangeCount > 0) {
     const range = selection.getRangeAt(0);
+
+    if (!element.contains(range.startContainer) || !element.contains(range.endContainer)) {
+      return { start, end };
+    }
 
     const preStartRange = range.cloneRange();
     preStartRange.selectNodeContents(element);
@@ -129,24 +135,8 @@ function setCaretPosition(element: HTMLElement, offset: number) {
   }
 }
 
-function generateHtmlFromText(text: string): string {
-  const words = text.split(/(\s+)/);
-  let html = "";
-  for (const word of words) {
-    if (word.trim() && props.emotes.has(word)) {
-      const url = props.emotes.get(word)?.url;
-      if (url) {
-        html += `<img src="${url}" data-emote-name="${word}" alt="${word}" class="inline-block h-[1.5em] align-middle mx-[2px]" contenteditable="false">`;
-      }
-    } else {
-      html += word
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/\n/g, "<br>");
-    }
-  }
-  return html;
+function toHtml(text: string): string {
+  return generateHtmlFromText(text, props.emotes);
 }
 
 function onInput() {
@@ -154,12 +144,16 @@ function onInput() {
   const plainText = extractPlainText(editorRef.value);
   emit("update:modelValue", plainText);
 
-  const expectedHtml = generateHtmlFromText(plainText);
+  const expectedHtml = toHtml(plainText);
   if (editorRef.value.innerHTML !== expectedHtml) {
     const offsets = getSelectionOffsetsWithin(editorRef.value);
     editorRef.value.innerHTML = expectedHtml;
     setCaretPosition(editorRef.value, offsets.end);
+    selectionOffsets.value = offsets;
+  } else {
+    selectionOffsets.value = getSelectionOffsetsWithin(editorRef.value);
   }
+  hasUserInteracted.value = true;
 }
 
 function onKeyDown(e: KeyboardEvent) {
@@ -219,8 +213,12 @@ function onCut(e: ClipboardEvent) {
 watch(
   () => props.modelValue,
   (newVal) => {
+    if (!newVal) {
+      selectionOffsets.value = { start: 0, end: 0 };
+      hasUserInteracted.value = false;
+    }
     if (editorRef.value && extractPlainText(editorRef.value) !== newVal) {
-      editorRef.value.innerHTML = generateHtmlFromText(newVal || "");
+      editorRef.value.innerHTML = toHtml(newVal || "");
     }
   }
 );
@@ -228,71 +226,61 @@ watch(
 function handleSelectionChange() {
   if (!editorRef.value) return;
   const sel = window.getSelection();
-  const images = editorRef.value.querySelectorAll("img[data-emote-name]");
+  if (!sel || sel.rangeCount === 0) return;
 
-  if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
-    images.forEach((img) => img.classList.remove("bg-blue-500/40"));
+  const isInside =
+    editorRef.value.contains(sel.anchorNode) || editorRef.value.contains(sel.focusNode);
+
+  if (!isInside) {
+    const highlighted = editorRef.value.querySelectorAll("img.bg-blue-500\\/40");
+    highlighted.forEach((img) => img.classList.remove("bg-blue-500/40"));
     return;
   }
 
-  images.forEach((img) => {
-    if (sel.containsNode(img, true)) {
-      img.classList.add("bg-blue-500/40");
-    } else {
-      img.classList.remove("bg-blue-500/40");
-    }
-  });
-
-  // Track caret offset when editor is focused
-  if (editorRef.value && editorRef.value.contains(sel.anchorNode)) {
-    selectionOffsets.value = getSelectionOffsetsWithin(editorRef.value);
+  const images = editorRef.value.querySelectorAll("img[data-emote-name]");
+  if (sel.isCollapsed) {
+    images.forEach((img) => img.classList.remove("bg-blue-500/40"));
+  } else {
+    images.forEach((img) => {
+      if (sel.containsNode(img, true)) {
+        img.classList.add("bg-blue-500/40");
+      } else {
+        img.classList.remove("bg-blue-500/40");
+      }
+    });
   }
+
+  selectionOffsets.value = getSelectionOffsetsWithin(editorRef.value);
+  hasUserInteracted.value = true;
 }
 
 function handleEmoteSelect(emote: PickerEmote) {
   const currentText = props.modelValue || "";
-
-  // Need spaces around the emote unless it's at start/end
-  let insertText = emote.name;
-
-  // Add space before if needed
-  if (selectionOffsets.value.start > 0 && currentText[selectionOffsets.value.start - 1] !== " ") {
-    insertText = " " + insertText;
-  }
-
-  // Add space after if needed
-  if (
-    selectionOffsets.value.end < currentText.length &&
-    currentText[selectionOffsets.value.end] !== " "
-  ) {
-    insertText = insertText + " ";
-  } else if (selectionOffsets.value.end === currentText.length) {
-    insertText = insertText + " "; // always add a space at the end to make it easier to continue typing
-  }
-
-  const newText =
-    currentText.slice(0, selectionOffsets.value.start) +
-    insertText +
-    currentText.slice(selectionOffsets.value.end);
+  const { newText, newOffset } = calculateEmoteInsertion(
+    currentText,
+    selectionOffsets.value,
+    emote.name,
+    hasUserInteracted.value
+  );
 
   emit("update:modelValue", newText);
 
   if (editorRef.value) {
-    editorRef.value.innerHTML = generateHtmlFromText(newText);
-    const newOffset = selectionOffsets.value.start + insertText.length;
+    editorRef.value.innerHTML = toHtml(newText);
     selectionOffsets.value = { start: newOffset, end: newOffset };
+    hasUserInteracted.value = true;
 
-    // Focus back and set caret
     setTimeout(() => {
-      editorRef.value?.focus();
-      setCaretPosition(editorRef.value!, newOffset);
+      if (!editorRef.value) return;
+      editorRef.value.focus();
+      setCaretPosition(editorRef.value, newOffset);
     }, 0);
   }
 }
 
 onMounted(() => {
   if (props.modelValue && editorRef.value) {
-    editorRef.value.innerHTML = generateHtmlFromText(props.modelValue);
+    editorRef.value.innerHTML = toHtml(props.modelValue);
   }
   document.addEventListener("selectionchange", handleSelectionChange);
 });
@@ -310,7 +298,6 @@ export default {
 
 <template>
   <div class="relative flex items-center w-full min-w-0">
-    <!-- Placeholder -->
     <div
       v-if="!modelValue && placeholder"
       class="absolute left-[13px] top-1/2 -translate-y-1/2 text-sm text-gray-500 pointer-events-none select-none"
@@ -318,7 +305,6 @@ export default {
       {{ placeholder }}
     </div>
 
-    <!-- Editor -->
     <div
       ref="editorRef"
       contenteditable="true"
@@ -328,6 +314,8 @@ export default {
       aria-multiline="true"
       @input="onInput"
       @keydown="onKeyDown"
+      @keyup="handleSelectionChange"
+      @pointerup="handleSelectionChange"
       @paste="onPaste"
       @copy="onCopy"
       @cut="onCut"
@@ -338,13 +326,3 @@ export default {
     </div>
   </div>
 </template>
-
-<style scoped>
-/* Remove focus outline to rely on custom rings */
-div[contenteditable]:empty:before {
-  content: attr(placeholder);
-  color: #6b7280;
-  pointer-events: none;
-  display: block; /* For Firefox */
-}
-</style>

--- a/apps/desktop/src/components/dialogs/_components/StreamChip.vue
+++ b/apps/desktop/src/components/dialogs/_components/StreamChip.vue
@@ -40,6 +40,7 @@ const formatViewers = (count?: number): string => {
   >
     <button
       type="button"
+      :data-testid="`stream-chip-${props.channel}`"
       class="flex items-center gap-1.5 px-2.5 py-1.5 w-full min-w-0 cursor-pointer text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40 rounded-md"
       :title="
         status?.isLive

--- a/apps/desktop/src/lib/__tests__/chatInput.spec.ts
+++ b/apps/desktop/src/lib/__tests__/chatInput.spec.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import { calculateEmoteInsertion, generateHtmlFromText } from "../chatInput";
+
+describe("chatInput utility unit tests", () => {
+  describe("calculateEmoteInsertion", () => {
+    it("should append emote at the end when caret is at the end of text", () => {
+      // Arrange
+      const text = "hello";
+      const offsets = { start: 5, end: 5 };
+      const emoteName = "Kappa";
+      const hasUserInteracted = true;
+
+      // Act
+      const result = calculateEmoteInsertion(text, offsets, emoteName, hasUserInteracted);
+
+      // Assert
+      expect(result.newText).toBe("hello Kappa ");
+      expect(result.newOffset).toBe(12);
+    });
+
+    it("should not duplicate leading space if text already ends with space", () => {
+      // Arrange
+      const text = "hello ";
+      const offsets = { start: 6, end: 6 };
+      const emoteName = "Kappa";
+      const hasUserInteracted = true;
+
+      // Act
+      const result = calculateEmoteInsertion(text, offsets, emoteName, hasUserInteracted);
+
+      // Assert
+      expect(result.newText).toBe("hello Kappa ");
+      expect(result.newOffset).toBe(12);
+    });
+
+    it("should insert emote in the middle when caret is positioned between words", () => {
+      // Arrange
+      const text = "hello world";
+      const offsets = { start: 5, end: 5 };
+      const emoteName = "Kappa";
+      const hasUserInteracted = true;
+
+      // Act
+      const result = calculateEmoteInsertion(text, offsets, emoteName, hasUserInteracted);
+
+      // Assert
+      expect(result.newText).toBe("hello Kappa world");
+      expect(result.newOffset).toBe(11);
+    });
+
+    it("should insert emote at the beginning without leading space when caret is at index 0", () => {
+      // Arrange
+      const text = "world";
+      const offsets = { start: 0, end: 0 };
+      const emoteName = "Kappa";
+      const hasUserInteracted = true;
+
+      // Act
+      const result = calculateEmoteInsertion(text, offsets, emoteName, hasUserInteracted);
+
+      // Assert
+      expect(result.newText).toBe("Kappa world");
+      expect(result.newOffset).toBe(6);
+    });
+
+    it("should insert emote into empty text", () => {
+      // Arrange
+      const text = "";
+      const offsets = { start: 0, end: 0 };
+      const emoteName = "Kappa";
+      const hasUserInteracted = false;
+
+      // Act
+      const result = calculateEmoteInsertion(text, offsets, emoteName, hasUserInteracted);
+
+      // Assert
+      expect(result.newText).toBe("Kappa ");
+      expect(result.newOffset).toBe(6);
+    });
+
+    it("should replace selected text range when range is highlighted", () => {
+      // Arrange
+      const text = "hello world";
+      const offsets = { start: 0, end: 5 };
+      const emoteName = "Kappa";
+      const hasUserInteracted = true;
+
+      // Act
+      const result = calculateEmoteInsertion(text, offsets, emoteName, hasUserInteracted);
+
+      // Assert
+      expect(result.newText).toBe("Kappa world");
+      expect(result.newOffset).toBe(5);
+    });
+
+    it("should append to the end if user has not interacted with pre-existing text", () => {
+      // Arrange
+      const text = "draft text";
+      const offsets = { start: 0, end: 0 };
+      const emoteName = "Kappa";
+      const hasUserInteracted = false;
+
+      // Act
+      const result = calculateEmoteInsertion(text, offsets, emoteName, hasUserInteracted);
+
+      // Assert
+      expect(result.newText).toBe("draft text Kappa ");
+      expect(result.newOffset).toBe(17);
+    });
+
+    it("should handle consecutive emote insertions correctly", () => {
+      // Arrange
+      const initialText = "hello";
+      const firstOffsets = { start: 5, end: 5 };
+      const hasUserInteracted = true;
+
+      // Act
+      const step1 = calculateEmoteInsertion(initialText, firstOffsets, "Kappa", hasUserInteracted);
+      const step2 = calculateEmoteInsertion(
+        step1.newText,
+        { start: step1.newOffset, end: step1.newOffset },
+        "LUL",
+        hasUserInteracted
+      );
+
+      // Assert
+      expect(step1.newText).toBe("hello Kappa ");
+      expect(step2.newText).toBe("hello Kappa LUL ");
+      expect(step2.newOffset).toBe(16);
+    });
+
+    it("should normalize inverted selection offsets where start is greater than end", () => {
+      // Arrange
+      const text = "hello world";
+      const offsets = { start: 5, end: 0 };
+      const emoteName = "Kappa";
+      const hasUserInteracted = true;
+
+      // Act
+      const result = calculateEmoteInsertion(text, offsets, emoteName, hasUserInteracted);
+
+      // Assert
+      expect(result.newText).toBe("Kappa world");
+      expect(result.newOffset).toBe(5);
+    });
+
+    it("should clamp offsets that exceed text length", () => {
+      // Arrange
+      const text = "test";
+      const offsets = { start: 99, end: 99 };
+      const emoteName = "Kappa";
+      const hasUserInteracted = true;
+
+      // Act
+      const result = calculateEmoteInsertion(text, offsets, emoteName, hasUserInteracted);
+
+      // Assert
+      expect(result.newText).toBe("test Kappa ");
+      expect(result.newOffset).toBe(11);
+    });
+
+    it("should clamp negative offsets to 0", () => {
+      // Arrange
+      const text = "test";
+      const offsets = { start: -5, end: -2 };
+      const emoteName = "Kappa";
+      const hasUserInteracted = true;
+
+      // Act
+      const result = calculateEmoteInsertion(text, offsets, emoteName, hasUserInteracted);
+
+      // Assert
+      expect(result.newText).toBe("Kappa test");
+      expect(result.newOffset).toBe(6);
+    });
+  });
+
+  describe("generateHtmlFromText", () => {
+    it("should convert known emote codes into img tags", () => {
+      // Arrange
+      const emotes = new Map([["Kappa", { url: "https://cdn.example.com/kappa.png" }]]);
+      const text = "hello Kappa world";
+
+      // Act
+      const html = generateHtmlFromText(text, emotes);
+
+      // Assert
+      expect(html).toContain('data-emote-name="Kappa"');
+      expect(html).toContain('src="https://cdn.example.com/kappa.png"');
+      expect(html).toContain("hello ");
+      expect(html).toContain(" world");
+    });
+
+    it("should escape special HTML characters in plain text", () => {
+      // Arrange
+      const emotes = new Map<string, { url: string }>();
+      const text = `<script>alert("xss")</script> & 'foo'`;
+
+      // Act
+      const html = generateHtmlFromText(text, emotes);
+
+      // Assert
+      expect(html).toBe("&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt; &amp; &#39;foo&#39;");
+    });
+
+    it("should escape quotes and special characters in emote attributes", () => {
+      // Arrange
+      const emotes = new Map([
+        ['<3"onmouseover="alert(1)', { url: 'https://cdn.example.com/heart.png?foo="bar"' }],
+      ]);
+      const text = '<3"onmouseover="alert(1)';
+
+      // Act
+      const html = generateHtmlFromText(text, emotes);
+
+      // Assert
+      expect(html).toContain('src="https://cdn.example.com/heart.png?foo=&quot;bar&quot;"');
+      expect(html).toContain('data-emote-name="&lt;3&quot;onmouseover=&quot;alert(1)"');
+      expect(html).toContain('alt="&lt;3&quot;onmouseover=&quot;alert(1)"');
+      expect(html).not.toContain('<3"');
+    });
+
+    it("should convert newlines to br tags", () => {
+      // Arrange
+      const emotes = new Map<string, { url: string }>();
+      const text = "line1\nline2";
+
+      // Act
+      const html = generateHtmlFromText(text, emotes);
+
+      // Assert
+      expect(html).toBe("line1<br>line2");
+    });
+  });
+});

--- a/apps/desktop/src/lib/__tests__/chatInput.spec.ts
+++ b/apps/desktop/src/lib/__tests__/chatInput.spec.ts
@@ -231,5 +231,17 @@ describe("chatInput utility unit tests", () => {
       // Assert
       expect(html).toBe("line1<br>line2");
     });
+
+    it("should fall back to plain text if emote is in map but has empty url", () => {
+      // Arrange
+      const emotes = new Map([["BrokenEmote", { url: "" }]]);
+      const text = "hello BrokenEmote world";
+
+      // Act
+      const html = generateHtmlFromText(text, emotes);
+
+      // Assert
+      expect(html).toBe("hello BrokenEmote world");
+    });
   });
 });

--- a/apps/desktop/src/lib/chatInput.ts
+++ b/apps/desktop/src/lib/chatInput.ts
@@ -1,0 +1,63 @@
+export interface EmoteInsertionResult {
+  newText: string;
+  newOffset: number;
+}
+
+function escapeAttr(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function calculateEmoteInsertion(
+  currentText: string,
+  offsets: { start: number; end: number },
+  emoteName: string,
+  hasUserInteracted: boolean
+): EmoteInsertionResult {
+  let start = Math.max(0, Math.min(offsets.start, currentText.length));
+  let end = Math.max(0, Math.min(offsets.end, currentText.length));
+
+  if (!hasUserInteracted && currentText.length > 0) {
+    start = currentText.length;
+    end = currentText.length;
+  }
+
+  if (start > end) [start, end] = [end, start];
+
+  let insertText = emoteName;
+
+  if (start > 0 && currentText[start - 1] !== " ") {
+    insertText = " " + insertText;
+  }
+
+  if (end < currentText.length && currentText[end] !== " ") {
+    insertText = insertText + " ";
+  } else if (end === currentText.length) {
+    insertText = insertText + " ";
+  }
+
+  const newText = currentText.slice(0, start) + insertText + currentText.slice(end);
+  const newOffset = start + insertText.length;
+
+  return { newText, newOffset };
+}
+
+export function generateHtmlFromText(text: string, emotes: Map<string, { url: string }>): string {
+  const words = text.split(/(\s+)/);
+  let html = "";
+  for (const word of words) {
+    if (word.trim() && emotes.has(word)) {
+      const url = emotes.get(word)?.url;
+      if (url) {
+        html += `<img src="${escapeAttr(url)}" data-emote-name="${escapeAttr(word)}" alt="${escapeAttr(word)}" class="inline-block h-[1.5em] align-middle mx-[2px]" contenteditable="false">`;
+      }
+    } else {
+      html += escapeAttr(word).replace(/\n/g, "<br>");
+    }
+  }
+  return html;
+}

--- a/apps/desktop/src/lib/chatInput.ts
+++ b/apps/desktop/src/lib/chatInput.ts
@@ -50,11 +50,9 @@ export function generateHtmlFromText(text: string, emotes: Map<string, { url: st
   const words = text.split(/(\s+)/);
   let html = "";
   for (const word of words) {
-    if (word.trim() && emotes.has(word)) {
-      const url = emotes.get(word)?.url;
-      if (url) {
-        html += `<img src="${escapeAttr(url)}" data-emote-name="${escapeAttr(word)}" alt="${escapeAttr(word)}" class="inline-block h-[1.5em] align-middle mx-[2px]" contenteditable="false">`;
-      }
+    const url = word.trim() ? emotes.get(word)?.url : undefined;
+    if (url) {
+      html += `<img src="${escapeAttr(url)}" data-emote-name="${escapeAttr(word)}" alt="${escapeAttr(word)}" class="inline-block h-[1.5em] align-middle mx-[2px]" contenteditable="false">`;
     } else {
       html += escapeAttr(word).replace(/\n/g, "<br>");
     }


### PR DESCRIPTION
## Description

Fixes a cursor tracking bug in Twitch and Kick native chat inputs where picking an emote from the emote picker inserted it at the beginning of the message, in the middle, or deleted previously selected text.

## Key Changes

- **Before:** Clicking an emote inserted it at index 0 (if you just typed), inside the middle of words (if you typed after inserting an earlier emote), or deleted characters (if you highlighted text previously and then clicked somewhere else).
- **After:** Emotes are inserted right where the caret is placed, or appended cleanly at the end if you haven't clicked into the input yet. Selecting text and picking an emote replaces only the active selection.
- **Root Cause:** In `ChatRichInput.vue`, `handleSelectionChange` returned early whenever `sel.isCollapsed` was true. Since a normal blinking caret is always collapsed, typing or clicking never updated `selectionOffsets`, leaving them stuck at `{ start: 0, end: 0 }` or holding stale range coordinates from older highlights.
- **Fixes Applied:**
  - Removed the premature return on collapsed selections in `handleSelectionChange`, keeping image selection cleanup intact.
  - Added containment checks in `getSelectionOffsetsWithin` so ranges outside the editor (like the emote picker's autofocus search input) don't trigger DOM exceptions.
  - Extracted caret calculation and HTML generation into pure helpers in `src/lib/chatInput.ts` with offset clamping and attribute escaping (`escapeAttr`).
  - Added defensive unmount checks in `setTimeout` before focusing or moving the caret.
  - Preserved whitespace separation on multiline paste instead of stripping newlines directly.

## Release Impact

- [x] **Patch** (Bug fix, internal refactor)
- [ ] **Minor** (New feature, UI setting, platform addition)
- [ ] **Major** (Breaking architectural changes)

## Test Plan

- [x] `bun run desktop:typecheck` passes
- [x] `bun run desktop:test` passes (444 unit tests passing, including 15 new tests in `chatInput.spec.ts`)
- [x] `bun run i18n:check` passes
- [x] Manual test:
  - Typed text and selected an emote -> appended to the end with proper spacing.
  - Placed cursor in the middle between words -> inserted emote without double spaces or broken words.
  - Selected a word and picked an emote -> replaced only the selected word.
  - Picked consecutive emotes from the picker -> appended each one sequentially.

## Notes

All caret math was decoupled into `src/lib/chatInput.ts` so edge cases like inverted selections (`start > end`), negative offsets, and HTML attribute injection are thoroughly tested in isolation without needing a mocked browser DOM.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved emote insertion in chat, including insertion at the cursor, replacement of selected text, and consecutive emote additions.
  - Improved handling of text selections and caret positioning when selecting or inserting emotes.
  - Chat content now preserves line breaks and displays emotes consistently.
  - Added safer handling for unusual or out-of-range text selections.
- **Tests**
  - Added coverage for emote insertion, formatting, escaping, and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->