### PR TITLE
fix(backend): atomic whisper download, global panic hook, ffmpeg remux timeout

### DIFF
--- a/apps/desktop/src-tauri/src/audio/transcriber.rs
+++ b/apps/desktop/src-tauri/src/audio/transcriber.rs
@@ -69,6 +69,20 @@ impl Drop for TempFileGuard {
     }
 }
 
+struct DownloadGuard {
+    temp_path: PathBuf,
+    success: bool,
+}
+
+impl Drop for DownloadGuard {
+    fn drop(&mut self) {
+        DOWNLOAD_IN_PROGRESS.store(false, Ordering::Relaxed);
+        if !self.success {
+            let _ = fs::remove_file(&self.temp_path);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -181,6 +195,10 @@ pub async fn download_whisper_model(model_name: String, app: AppHandle) -> Resul
     // Reset cancellation flag before starting
     CANCEL_DOWNLOAD.store(false, Ordering::Relaxed);
     DOWNLOAD_IN_PROGRESS.store(true, Ordering::Relaxed);
+    let mut guard = DownloadGuard {
+        temp_path: temp_path.clone(),
+        success: false,
+    };
 
     use std::io::Write;
     let mut file = std::fs::File::create(&temp_path)
@@ -196,8 +214,6 @@ pub async fn download_whisper_model(model_name: String, app: AppHandle) -> Resul
     while let Some(chunk_result) = stream.next().await {
         if CANCEL_DOWNLOAD.load(Ordering::Relaxed) {
             drop(file);
-            let _ = fs::remove_file(&temp_path);
-            DOWNLOAD_IN_PROGRESS.store(false, Ordering::Relaxed);
             return Err("Download cancelled by user".to_string());
         }
 
@@ -228,10 +244,9 @@ pub async fn download_whisper_model(model_name: String, app: AppHandle) -> Resul
     // Explicit drop ensures the file handle is flushed and closed on Windows
     // before `rename`, which would otherwise fail with a sharing violation (ERROR_SHARING_VIOLATION).
     drop(file);
-    let rename_result = fs::rename(&temp_path, &dest_path)
-        .map_err(|e| format!("failed to finalize model file: {e}"));
-    DOWNLOAD_IN_PROGRESS.store(false, Ordering::Relaxed);
-    rename_result?;
+    fs::rename(&temp_path, &dest_path)
+        .map_err(|e| format!("failed to finalize model file: {e}"))?;
+    guard.success = true;
 
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/audio/transcriber.rs
+++ b/apps/desktop/src-tauri/src/audio/transcriber.rs
@@ -121,6 +121,7 @@ fn timestamp_ms() -> u64 {
 pub const TRANSCRIPTION_SUPPORTED: bool = cfg!(target_os = "windows");
 
 static CANCEL_DOWNLOAD: AtomicBool = AtomicBool::new(false);
+static DOWNLOAD_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 #[tauri::command]
 pub fn cancel_whisper_download() {
@@ -168,15 +169,25 @@ pub async fn download_whisper_model(model_name: String, app: AppHandle) -> Resul
 
     let total = response.content_length().unwrap_or(0);
     let dest_path = model_path(&app, &model_name)?;
+    // Append `.tmp` to the full filename (e.g. `ggml-base.bin` → `ggml-base.bin.tmp`)
+    // so that a partial download is never mistaken for a complete model on disk.
+    // Stale `.tmp` files left by crashed sessions are cleaned up in `get_transcription_status`.
+    let temp_name = format!(
+        "{}.tmp",
+        dest_path.file_name().unwrap_or_default().to_string_lossy()
+    );
+    let temp_path = dest_path.with_file_name(temp_name);
 
     // Reset cancellation flag before starting
     CANCEL_DOWNLOAD.store(false, Ordering::Relaxed);
+    DOWNLOAD_IN_PROGRESS.store(true, Ordering::Relaxed);
 
     use std::io::Write;
-    let mut file = std::fs::File::create(&dest_path)
-        .map_err(|e| format!("failed to create model file: {e}"))?;
+    let mut file = std::fs::File::create(&temp_path)
+        .map_err(|e| format!("failed to create temp model file: {e}"))?;
 
-    // Stream response body directly to disk, emitting progress events on each chunk.
+    // Stream response body to a .tmp file. Only renamed to .bin on full success,
+    // preventing corrupted models from appearing installed after interrupted downloads.
     let mut downloaded: u64 = 0;
     let mut stream = response.bytes_stream();
     let mut last_emit = std::time::Instant::now();
@@ -184,9 +195,9 @@ pub async fn download_whisper_model(model_name: String, app: AppHandle) -> Resul
 
     while let Some(chunk_result) = stream.next().await {
         if CANCEL_DOWNLOAD.load(Ordering::Relaxed) {
-            // User cancelled the download
             drop(file);
-            let _ = fs::remove_file(&dest_path);
+            let _ = fs::remove_file(&temp_path);
+            DOWNLOAD_IN_PROGRESS.store(false, Ordering::Relaxed);
             return Err("Download cancelled by user".to_string());
         }
 
@@ -213,6 +224,14 @@ pub async fn download_whisper_model(model_name: String, app: AppHandle) -> Resul
             );
         }
     }
+
+    // Explicit drop ensures the file handle is flushed and closed on Windows
+    // before `rename`, which would otherwise fail with a sharing violation (ERROR_SHARING_VIOLATION).
+    drop(file);
+    let rename_result = fs::rename(&temp_path, &dest_path)
+        .map_err(|e| format!("failed to finalize model file: {e}"));
+    DOWNLOAD_IN_PROGRESS.store(false, Ordering::Relaxed);
+    rename_result?;
 
     Ok(())
 }
@@ -250,6 +269,12 @@ pub fn get_transcription_status(
         .filter_map(|entry| entry.ok())
         .filter_map(|entry| {
             let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with("ggml-") && name.ends_with(".bin.tmp") {
+                if !DOWNLOAD_IN_PROGRESS.load(Ordering::Relaxed) {
+                    let _ = fs::remove_file(entry.path());
+                }
+                return None;
+            }
             if name.starts_with("ggml-") && name.ends_with(".bin") {
                 // Extract the model name from `ggml-<name>.bin`
                 let stripped = name

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2,6 +2,11 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    std::panic::set_hook(Box::new(|panic_info| {
+        log::error!("CRITICAL UNHANDLED PANIC: {panic_info}");
+        eprintln!("Unhandled panic: {panic_info}");
+    }));
+
     #[cfg(target_os = "linux")]
     std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2,9 +2,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    std::panic::set_hook(Box::new(|panic_info| {
-        log::error!("CRITICAL UNHANDLED PANIC: {panic_info}");
-        eprintln!("Unhandled panic: {panic_info}");
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        log::error!("PANIC: {panic_info}");
+        default_hook(panic_info);
     }));
 
     #[cfg(target_os = "linux")]

--- a/apps/desktop/src-tauri/src/recording/commands.rs
+++ b/apps/desktop/src-tauri/src/recording/commands.rs
@@ -539,43 +539,55 @@ async fn run_ffmpeg_remux(
     let ffmpeg_exe =
         crate::recording::installer::get_ffmpeg_exe(app).map_err(RecordingError::SpawnFailed)?;
     let args = ffmpeg_remux_args(ts_path, mp4_path);
-    let (mut rx, _child) = app
+    let (mut rx, child) = app
         .shell()
         .command(ffmpeg_exe.to_string_lossy().to_string())
         .args(&args)
         .spawn()
         .map_err(|e| RecordingError::SpawnFailed(e.to_string()))?;
 
-    while let Some(event) = rx.recv().await {
-        match event {
-            CommandEvent::Stdout(line) => {
-                let text = String::from_utf8_lossy(&line);
-                for l in text.lines() {
-                    if let Some(rest) = l.strip_prefix("total_size=") {
-                        if let Ok(bytes) = rest.parse::<u64>() {
-                            let _ = app.emit(
-                                "recording:remux-progress",
-                                RemuxProgressPayload {
-                                    stream_id: stream_id.to_string(),
-                                    bytes,
-                                    total_bytes: ts_size,
-                                },
-                            );
+    let remux_timeout = Duration::from_secs(30 * 60);
+    let deadline = tokio::time::Instant::now() + remux_timeout;
+
+    loop {
+        match tokio::time::timeout_at(deadline, rx.recv()).await {
+            Err(_) => {
+                let _ = child.kill();
+                return Err(RecordingError::SpawnFailed(
+                    "ffmpeg remux timed out after 30 minutes".into(),
+                ));
+            }
+            Ok(None) => break,
+            Ok(Some(event)) => match event {
+                CommandEvent::Stdout(line) => {
+                    let text = String::from_utf8_lossy(&line);
+                    for l in text.lines() {
+                        if let Some(rest) = l.strip_prefix("total_size=") {
+                            if let Ok(bytes) = rest.parse::<u64>() {
+                                let _ = app.emit(
+                                    "recording:remux-progress",
+                                    RemuxProgressPayload {
+                                        stream_id: stream_id.to_string(),
+                                        bytes,
+                                        total_bytes: ts_size,
+                                    },
+                                );
+                            }
                         }
                     }
                 }
-            }
-            CommandEvent::Terminated(payload) => {
-                return if payload.code == Some(0) {
-                    Ok(())
-                } else {
-                    Err(RecordingError::SpawnFailed(format!(
-                        "ffmpeg exited with code {:?}",
-                        payload.code
-                    )))
-                };
-            }
-            _ => {}
+                CommandEvent::Terminated(payload) => {
+                    return if payload.code == Some(0) {
+                        Ok(())
+                    } else {
+                        Err(RecordingError::SpawnFailed(format!(
+                            "ffmpeg exited with code {:?}",
+                            payload.code
+                        )))
+                    };
+                }
+                _ => {}
+            },
         }
     }
 


### PR DESCRIPTION
## Description

Three silent failure modes in the Rust backend that could bite users in bad timing scenarios: corrupted whisper models after interrupted downloads, unhandled panics dying with no log trace, and ffmpeg stalling indefinitely on a corrupt recording file.

## Key Changes

- Atomic whisper download: the model is written to ggml-<name>.bin.tmp during transfer and only renamed to .bin once the stream finishes. An interrupted download leaves a stale .tmp at worst, which gets cleaned up on the next status check. Previously it wrote directly to .bin, so a cancelled or crashed download left a truncated file that whisper-cli would load and crash on.
- DOWNLOAD_IN_PROGRESS flag: get_transcription_status was deleting any .tmp it found on startup without checking whether a download was active. If the user happened to call it mid-download, it would delete the file being written. The flag prevents that.
- Global panic hook: std::panic::set_hook is now registered before pp_lib::run(). Any unhandled panic in any thread — audio capture, WebSocket, remux — now lands in the Tauri log via log::error! plus stderr, rather than disappearing silently.
- ffmpeg remux timeout: 
un_ffmpeg_remux now has a 30-minute hard deadline via 	okio::time::timeout_at. On timeout, the child process is killed explicitly before returning the error. Previously _child was dropped right after spawn, so a timed-out ffmpeg kept running as a zombie with no way to kill it.

## Release Impact

- [x] **Patch** (Bug fix, internal refactor)
- [ ] **Minor** (New feature, UI setting, platform addition)
- [ ] **Major** (Breaking architectural changes)

## Test Plan

- [x] \bun run desktop:typecheck\ passes
- [x] \bun run desktop:test\ passes
- [x] \bun run i18n:check\ passes (if UI strings were added or changed)
- [x] Manual test: cargo check and cargo test pass clean with no warnings

## Notes

All three issues were identified through static analysis and adversarial edge case review — no user-facing crash reports yet. The ffmpeg timeout is set to 30 minutes, which is conservative enough to never trip on a normal recording while still unblocking the shutdown path if the file is corrupt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription model downloads by preventing incomplete files from appearing as installed models.
  * Automatically cleans up interrupted or stale model downloads.
  * Added a timeout for recording conversions to prevent processes from running indefinitely.
  * Improved error reporting when recording conversion processes fail or exceed the time limit.
  * Added clearer diagnostics for unexpected application errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->